### PR TITLE
Smaller tests, attribute checking, temp files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Rscript -e "install.packages(c('rJava'))"
 R CMD INSTALL .
 ```
 
+Run this before you start any work, and then check that the setup worked by running `Rscript -e 'library(XLConnect)'
+
 ## Common commands
 
 ### Install the local source package
@@ -53,6 +55,9 @@ Run a specific test file:
 options(FULL.TEST.SUITE=TRUE)
 testthat::test_file("tests/testthat/test.loadWorkbook.R")
 ```
+
+When making multiple changes, run the tests after each change and fix any failures before moving on to the next change.
+In that case it's ok to run only the tests that you expect to be impacted.
 
 ### Run RUnit tests
 

--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ library(testthat)
 library(XLConnect)
 test_dir("tests/testthat")
 ```
+
+Local Coverage Report
+---------------------
+
+For a local html report, you need to `install.packages(c("DT", "htmltools"))`
+
+You can create a local coverage report, viewable in a web browser, by running
+```r
+library(covr)
+covr:report()
+```

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -15,7 +15,13 @@ withr::local_locale(
 library(rJava)
 jlocale <- J("java.util.Locale")
 jlocale$setDefault(jlocale$US)
-
+if (!getOption("FULL.TEST.SUITE", default = FALSE)) {
+  Sys.setenv("OMP_THREAD_LIMIT" = 1)
+}
+withr::local_options(
+  .new = list(XLConnect.setCustomAttributes = TRUE),
+  .local_envir = testthat::teardown_env()
+)
 # Clean up variables from this script's environment
 # Note: new_java_params was already not defined, removing it from rm()
 # j_params is defined earlier and used in options_to_set, so it's cleaned up here.

--- a/tests/testthat/test.colidx.R
+++ b/tests/testthat/test.colidx.R
@@ -1,8 +1,17 @@
-test_that("test.colidx", {
+test_that("col2idx converts column names to indices", {
     expect_equal(c(1, 27, 6102), col2idx(c("A", "AA", "HZR")))
+})
+
+test_that("idx2col converts indices to column names", {
     expect_equal(c("A", "AA", "HZR"), idx2col(c(1, 27, 6102)))
+})
+
+test_that("col2idx and idx2col are inverse functions", {
     expect_equal(c("AWT", "FRT"), idx2col(col2idx(c("AWT", "FRT"))))
     expect_equal(c(3628, 867), col2idx(idx2col(c(3628, 867))))
+})
+
+test_that("idx2col handles invalid indices", {
     expect_equal(rep("", 3), idx2col(c(0, -1, -2628)))
 })
 

--- a/tests/testthat/test.dataframeConversion.R
+++ b/tests/testthat/test.dataframeConversion.R
@@ -2,8 +2,7 @@ test_that("test.dataframeConversion - always run", {
     testDataFrame <- function(df) {
         res <- XLConnect:::dataframeFromJava(XLConnect:::dataframeToJava(df), 
             check.names = TRUE)
-        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE,
-            check.names = TRUE)
+        expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope", "row.names"))
     }
     cdf <- data.frame(Column.A = c(1, 2, 3, NA, 5, Inf, 7, 8, 
         NA, 10), Column.B = c(-4, -3, NA, -Inf, 0, NA, NA, 3, 
@@ -39,8 +38,7 @@ test_that("test.dataframeConversion - full test suite only", {
     testDataFrame <- function(df) {
         res <- XLConnect:::dataframeFromJava(XLConnect:::dataframeToJava(df),
             check.names = TRUE)
-        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE,
-            check.names = TRUE)
+        expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope", "row.names"))
     }
     testDataFrame(mtcars)
     testDataFrame(airquality)

--- a/tests/testthat/test.dataframeConversion.R
+++ b/tests/testthat/test.dataframeConversion.R
@@ -2,7 +2,7 @@ test_that("test.dataframeConversion - always run", {
     testDataFrame <- function(df) {
         res <- XLConnect:::dataframeFromJava(XLConnect:::dataframeToJava(df), 
             check.names = TRUE)
-        expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope", "row.names"))
+        expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope"))
     }
     cdf <- data.frame(Column.A = c(1, 2, 3, NA, 5, Inf, 7, 8, 
         NA, 10), Column.B = c(-4, -3, NA, -Inf, 0, NA, NA, 3, 

--- a/tests/testthat/test.dataframeConversion.R
+++ b/tests/testthat/test.dataframeConversion.R
@@ -2,7 +2,7 @@ test_that("test.dataframeConversion - always run", {
     testDataFrame <- function(df) {
         res <- XLConnect:::dataframeFromJava(XLConnect:::dataframeToJava(df), 
             check.names = TRUE)
-        expect_equal(normalizeDataframe(df), res, check.attributes = FALSE,
+        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE,
             check.names = TRUE)
     }
     cdf <- data.frame(Column.A = c(1, 2, 3, NA, 5, Inf, 7, 8, 
@@ -39,7 +39,7 @@ test_that("test.dataframeConversion - full test suite only", {
     testDataFrame <- function(df) {
         res <- XLConnect:::dataframeFromJava(XLConnect:::dataframeToJava(df),
             check.names = TRUE)
-        expect_equal(normalizeDataframe(df), res, check.attributes = FALSE,
+        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE,
             check.names = TRUE)
     }
     testDataFrame(mtcars)

--- a/tests/testthat/test.dumpAndRestore.R
+++ b/tests/testthat/test.dumpAndRestore.R
@@ -20,7 +20,7 @@ test_that("test.dumpAndRestore - full test suite only", {
         sapply(names(out)[out], function(obj) {
             data.orig = normalizeDataframe(get(obj, pos = pos))
             data.restored = get(obj)
-            expect_equal(data.orig, data.restored, ignore_attr = c("worksheetScope", "row.names"))
+            expect_equal(data.orig, data.restored, ignore_attr = c("worksheetScope"))
             expect_equal(attr(data.orig, "row.names"), attr(data.restored,
               "row.names"))
         })

--- a/tests/testthat/test.dumpAndRestore.R
+++ b/tests/testthat/test.dumpAndRestore.R
@@ -20,7 +20,7 @@ test_that("test.dumpAndRestore - full test suite only", {
         sapply(names(out)[out], function(obj) {
             data.orig = normalizeDataframe(get(obj, pos = pos))
             data.restored = get(obj)
-            expect_equal(data.orig, data.restored, check.attributes = FALSE,
+            expect_equal(data.orig, data.restored, ignore_attr = TRUE,
               check.names = TRUE)
             expect_equal(attr(data.orig, "row.names"), attr(data.restored,
               "row.names"))

--- a/tests/testthat/test.dumpAndRestore.R
+++ b/tests/testthat/test.dumpAndRestore.R
@@ -20,8 +20,7 @@ test_that("test.dumpAndRestore - full test suite only", {
         sapply(names(out)[out], function(obj) {
             data.orig = normalizeDataframe(get(obj, pos = pos))
             data.restored = get(obj)
-            expect_equal(data.orig, data.restored, ignore_attr = TRUE,
-              check.names = TRUE)
+            expect_equal(data.orig, data.restored, ignore_attr = c("worksheetScope", "row.names"))
             expect_equal(attr(data.orig, "row.names"), attr(data.restored,
               "row.names"))
         })

--- a/tests/testthat/test.extractSheetName.R
+++ b/tests/testthat/test.extractSheetName.R
@@ -1,5 +1,6 @@
-test_that("test.extractSheetName", {
-    expect_equal(c("MySheet", "My Sheet", "My!Sheet", ""), extractSheetName(c("MySheet!$A$1", 
-        "'My Sheet'!$A$1", "'My!Sheet'!$A$1", "MySheet")))
+test_that("extractSheetName extracts sheet names from formulas", {
+    formulas <- c("MySheet!$A$1", "'My Sheet'!$A$1", "'My!Sheet'!$A$1", "MySheet")
+    expected <- c("MySheet", "My Sheet", "My!Sheet", "")
+    expect_equal(extractSheetName(formulas), expected)
 })
 

--- a/tests/testthat/test.loadWorkbook.R
+++ b/tests/testthat/test.loadWorkbook.R
@@ -1,4 +1,3 @@
-context("loadWorkbook Functionality")
 
 test_that("loading non-existent files throws an error", {
     expect_error(loadWorkbook(rsrc("fileWhichDoesNotExist.xls")))
@@ -13,35 +12,35 @@ test_that("loading existing valid XLS and XLSX files works", {
     expect_true(is(wb_xlsx, "workbook"))
 })
 
-test_that("creating new XLS and XLSX files on the fly works", {
-    # Test creating an XLS file
+test_that("creating a new XLS file on the fly works", {
     file_to_create_xls <- rsrc("fileCreatedOnTheFly.xls")
-    on.exit(if (file.exists(file_to_create_xls)) file.remove(file_to_create_xls), add = TRUE) # Ensure cleanup
+    on.exit(if (file.exists(file_to_create_xls)) file.remove(file_to_create_xls))
 
     wb_create_xls <- loadWorkbook(file_to_create_xls, create = TRUE)
     expect_true(is(wb_create_xls, "workbook"))
-    saveWorkbook(wb_create_xls, file_to_create_xls) # Ensure file is written
+    saveWorkbook(wb_create_xls, file_to_create_xls)
     expect_true(file.exists(file_to_create_xls))
+})
 
-    # Test creating an XLSX file
+test_that("creating a new XLSX file on the fly works", {
     file_to_create_xlsx <- rsrc("fileCreatedOnTheFly.xlsx")
-    on.exit(if (file.exists(file_to_create_xlsx)) file.remove(file_to_create_xlsx), add = TRUE) # Ensure cleanup
+    on.exit(if (file.exists(file_to_create_xlsx)) file.remove(file_to_create_xlsx))
 
     wb_create_xlsx <- loadWorkbook(file_to_create_xlsx, create = TRUE)
     expect_true(is(wb_create_xlsx, "workbook"))
-    saveWorkbook(wb_create_xlsx, file_to_create_xlsx) # Ensure file is written
+    saveWorkbook(wb_create_xlsx, file_to_create_xlsx)
     expect_true(file.exists(file_to_create_xlsx))
 })
 
-test_that("loading password-protected files works correctly", {
-    # Test case 1: testBug61.xlsx
+test_that("loading a password-protected file (testBug61.xlsx) works", {
     pwdProtectedFile1 <- rsrc("testBug61.xlsx")
     expect_error(loadWorkbook(pwdProtectedFile1), "EncryptedDocumentException (Java): The supplied spreadsheet is protected, but no password was supplied", fixed = TRUE)
     expect_error(loadWorkbook(pwdProtectedFile1, password = "wrong"), "EncryptedDocumentException (Java): Password incorrect", fixed = TRUE)
     wb_pwd1 <- loadWorkbook(pwdProtectedFile1, password = "mirai")
     expect_true(is(wb_pwd1, "workbook"))
+})
 
-    # Test case 2: testBug106.xlsx
+test_that("loading a password-protected file (testBug106.xlsx) works", {
     pwdProtectedFile2 <- rsrc("testBug106.xlsx")
     expect_error(loadWorkbook(pwdProtectedFile2), "EncryptedDocumentException (Java): The supplied spreadsheet is protected, but no password was supplied", fixed = TRUE)
     expect_error(loadWorkbook(pwdProtectedFile2, password = "wrong"), "EncryptedDocumentException (Java): Password incorrect", fixed = TRUE)

--- a/tests/testthat/test.with.workbook.R
+++ b/tests/testthat/test.with.workbook.R
@@ -1,28 +1,15 @@
-context("with.workbook functionality")
+test_that("with.workbook correctly loads data from an XLS file", {
+    wb.xls <- loadWorkbook(rsrc("testWithWorkbook.xls"), create = FALSE)
+    with(wb.xls, {
+        expect_true(all(dim(AA) == c(8, 3)), info = "XLS: Check dimensions of sheet AA")
+        expect_true(all(dim(BB) == c(5, 5)), info = "XLS: Check dimensions of sheet BB")
+    }, header = FALSE)
+})
 
-test_that("with.workbook correctly loads data from specified sheets", {
-    wb.xls <- loadWorkbook(rsrc("testWithWorkbook.xls"),
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook(rsrc("testWithWorkbook.xlsx"),
-        create = FALSE
-    )
-
-    # Test with XLS workbook
-    with(wb.xls,
-        {
-            expect_true(all(dim(AA) == c(8, 3)), info = "XLS: Check dimensions of sheet AA")
-            expect_true(all(dim(BB) == c(5, 5)), info = "XLS: Check dimensions of sheet BB")
-        },
-        header = FALSE # Assuming this applies to how with.workbook reads the sheets
-    )
-
-    # Test with XLSX workbook
-    with(wb.xlsx,
-        {
-            expect_true(all(dim(AA) == c(8, 3)), info = "XLSX: Check dimensions of sheet AA")
-            expect_true(all(dim(BB) == c(5, 5)), info = "XLSX: Check dimensions of sheet BB")
-        },
-        header = FALSE # Assuming this applies to how with.workbook reads the sheets
-    )
+test_that("with.workbook correctly loads data from an XLSX file", {
+    wb.xlsx <- loadWorkbook(rsrc("testWithWorkbook.xlsx"), create = FALSE)
+    with(wb.xlsx, {
+        expect_true(all(dim(AA) == c(8, 3)), info = "XLSX: Check dimensions of sheet AA")
+        expect_true(all(dim(BB) == c(5, 5)), info = "XLSX: Check dimensions of sheet BB")
+    }, header = FALSE)
 })

--- a/tests/testthat/test.workbook.appendNamedRegion.R
+++ b/tests/testthat/test.workbook.appendNamedRegion.R
@@ -9,8 +9,7 @@ test_overwrite_formula_helper <- function(wb, data_to_append, expected_read_data
     )
     res <- readNamedRegion(wb, name = name_to_use)
     expect_equal(res, normalizeDataframe(expected_read_data),
-        ignore_attr = TRUE,
-        check.names = TRUE
+        ignore_attr = c("worksheetScope", "row.names")
     )
     expect_equal(
         getReferenceCoordinatesForName(wb, name_to_use),

--- a/tests/testthat/test.workbook.appendNamedRegion.R
+++ b/tests/testthat/test.workbook.appendNamedRegion.R
@@ -9,7 +9,7 @@ test_overwrite_formula_helper <- function(wb, data_to_append, expected_read_data
     )
     res <- readNamedRegion(wb, name = name_to_use)
     expect_equal(res, normalizeDataframe(expected_read_data),
-        check.attributes = FALSE,
+        ignore_attr = TRUE,
         check.names = TRUE
     )
     expect_equal(

--- a/tests/testthat/test.workbook.clearRange.R
+++ b/tests/testthat/test.workbook.clearRange.R
@@ -1,34 +1,25 @@
-test_that("test.workbook.clearRange", {
-    wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx",
-        create = FALSE
-    )
+test_that("clearRange works correctly for XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls", create = FALSE)
     checkDf <- data.frame(
         one = 1:5, two = c(NA, NA, 8, 9, 10),
-        three = c(NA, NA, 13, 14, 15), four = 16:20, five = c(
-            21,
-            22, NA, NA, 25
-        ), six = c(26, 27, NA, NA, 30), seven = 31:35,
+        three = c(NA, NA, 13, 14, 15), four = 16:20, five = c(21, 22, NA, NA, 25),
+        six = c(26, 27, NA, NA, 30), seven = 31:35,
         stringsAsFactors = F
     )
-    clearRange(wb.xls, "clearRange", c(c(4, 4, 5, 5), c(
-        6, 7,
-        7, 8
-    )))
-    res <- readWorksheet(wb.xls, "clearRange",
-        region = "C3:I8",
-        header = TRUE
-    )
+    clearRange(wb.xls, "clearRange", c(c(4, 4, 5, 5), c(6, 7, 7, 8)))
+    res <- readWorksheet(wb.xls, "clearRange", region = "C3:I8", header = TRUE)
     expect_equal(checkDf, res)
-    clearRange(wb.xlsx, "clearRange", c(c(4, 4, 5, 5), c(
-        6, 7,
-        7, 8
-    )))
-    res <- readWorksheet(wb.xlsx, "clearRange",
-        region = "C3:I8",
-        header = TRUE
+})
+
+test_that("clearRange works correctly for XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx", create = FALSE)
+    checkDf <- data.frame(
+        one = 1:5, two = c(NA, NA, 8, 9, 10),
+        three = c(NA, NA, 13, 14, 15), four = 16:20, five = c(21, 22, NA, NA, 25),
+        six = c(26, 27, NA, NA, 30), seven = 31:35,
+        stringsAsFactors = F
     )
+    clearRange(wb.xlsx, "clearRange", c(c(4, 4, 5, 5), c(6, 7, 7, 8)))
+    res <- readWorksheet(wb.xlsx, "clearRange", region = "C3:I8", header = TRUE)
     expect_equal(checkDf, res)
 })

--- a/tests/testthat/test.workbook.clearRangeFromReference.R
+++ b/tests/testthat/test.workbook.clearRangeFromReference.R
@@ -1,33 +1,25 @@
-test_that("test.workbook.clearRangeFromReference", {
-    wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx",
-        create = FALSE
-    )
+test_that("clearRangeFromReference works correctly for XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls", create = FALSE)
     checkDf <- data.frame(
         one = 1:5, two = c(NA, NA, 8, 9, 10),
-        three = c(NA, NA, 13, 14, 15), four = 16:20, five = c(
-            21,
-            22, NA, NA, 25
-        ), six = c(26, 27, NA, NA, 30), seven = 31:35,
+        three = c(NA, NA, 13, 14, 15), four = 16:20, five = c(21, 22, NA, NA, 25),
+        six = c(26, 27, NA, NA, 30), seven = 31:35,
         stringsAsFactors = F
     )
-    clearRangeFromReference(wb.xls, c(
-        "clearRangeFromReference!D4:E5",
-        "clearRangeFromReference!G6:H7"
-    ))
-    res <- readWorksheet(wb.xls, "clearRangeFromReference",
-        region = "C3:I8",
-        header = TRUE
-    )
+    clearRangeFromReference(wb.xls, c("clearRangeFromReference!D4:E5", "clearRangeFromReference!G6:H7"))
+    res <- readWorksheet(wb.xls, "clearRangeFromReference", region = "C3:I8", header = TRUE)
     expect_equal(checkDf, res)
-    clearRangeFromReference(wb.xlsx, c(
-        "clearRangeFromReference!D4:E5",
-        "clearRangeFromReference!G6:H7"
-    ))
-    res <- readWorksheet(wb.xlsx, "clearRangeFromReference",
-        region = "C3:I8", header = TRUE
+})
+
+test_that("clearRangeFromReference works correctly for XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx", create = FALSE)
+    checkDf <- data.frame(
+        one = 1:5, two = c(NA, NA, 8, 9, 10),
+        three = c(NA, NA, 13, 14, 15), four = 16:20, five = c(21, 22, NA, NA, 25),
+        six = c(26, 27, NA, NA, 30), seven = 31:35,
+        stringsAsFactors = F
     )
+    clearRangeFromReference(wb.xlsx, c("clearRangeFromReference!D4:E5", "clearRangeFromReference!G6:H7"))
+    res <- readWorksheet(wb.xlsx, "clearRangeFromReference", region = "C3:I8", header = TRUE)
     expect_equal(checkDf, res)
 })

--- a/tests/testthat/test.workbook.clearSheet.R
+++ b/tests/testthat/test.workbook.clearSheet.R
@@ -1,22 +1,15 @@
-test_that("test.workbook.clearSheet", {
-    wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx",
-        create = FALSE
-    )
+test_that("clearSheet works correctly for XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls", create = FALSE)
     clearSheet(wb.xls, c("clearSheet1", "clearSheet2"))
     res1 <- getLastRow(wb.xls, "clearSheet1")
     res2 <- getLastRow(wb.xls, "clearSheet2")
-    expect_equal(c(clearSheet1 = 1, clearSheet2 = 1), c(
-        res1,
-        res2
-    ))
+    expect_equal(c(clearSheet1 = 1, clearSheet2 = 1), c(res1, res2))
+})
+
+test_that("clearSheet works correctly for XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx", create = FALSE)
     clearSheet(wb.xlsx, c("clearSheet1", "clearSheet2"))
     res1 <- getLastRow(wb.xlsx, "clearSheet1")
     res2 <- getLastRow(wb.xlsx, "clearSheet2")
-    expect_equal(c(clearSheet1 = 1, clearSheet2 = 1), c(
-        res1,
-        res2
-    ))
+    expect_equal(c(clearSheet1 = 1, clearSheet2 = 1), c(res1, res2))
 })

--- a/tests/testthat/test.workbook.createName.R
+++ b/tests/testthat/test.workbook.createName.R
@@ -25,14 +25,14 @@ test_that("test.workbook.createName", {
     expect_error(createName(wb.xlsx, "ImHere", "There!$A$2"), "IllegalArgumentException")
     createName(wb.xls, "CurrentlyHere", "CurrentlyHere!$D$8")
     createName(wb.xls, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
-    expect_equal(TRUE, existsName(wb.xls, "CurrentlyHere"))
+    expect_true(existsName(wb.xls, "CurrentlyHere"))
     createName(wb.xlsx, "CurrentlyHere", "CurrentlyHere!$D$8")
     createName(wb.xlsx, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
-    expect_equal(TRUE, existsName(wb.xlsx, "CurrentlyHere"))
+    expect_true(existsName(wb.xlsx, "CurrentlyHere"))
     expect_error(createName(wb.xls, "aName", "Test!A1A4"), "IllegalArgumentException")
     # This call should not produce an error:
     createName(wb.xls, "aName", "Test!A1")
-    expect_equal(TRUE, existsName(wb.xls, "aName"))
+    expect_true(existsName(wb.xls, "aName"))
     sheetName <- "Test_Scoped_Sheet"
     createSheet(wb.xls, name = sheetName)
     createSheet(wb.xlsx, name = sheetName)

--- a/tests/testthat/test.workbook.createSheet.R
+++ b/tests/testthat/test.workbook.createSheet.R
@@ -1,25 +1,41 @@
-test_that("test.workbook.createSheet", {
-    wb.xls <- loadWorkbook("resources/createSheet.xls",
-        create = TRUE
-    )
-    wb.xlsx <- loadWorkbook("resources/createSheet.xlsx",
-        create = TRUE
-    )
+test_that("createSheet throws an error for invalid sheet names in XLS", {
+    wb.xls <- loadWorkbook("resources/createSheet.xls", create = TRUE)
     expect_error(createSheet(wb.xls, "'Invalid Sheet Name"), "IllegalArgumentException")
-    expect_error(createSheet(wb.xlsx, "'Invalid Sheet Name"), "IllegalArgumentException")
     expect_error(createSheet(wb.xls, "Invalid Sheet Name'"), "IllegalArgumentException")
-    expect_error(createSheet(wb.xlsx, "Invalid Sheet Name'"), "IllegalArgumentException")
     expect_error(createSheet(wb.xls, "A very very very very very very very very long name"), "IllegalArgumentException")
+})
+
+test_that("createSheet throws an error for invalid sheet names in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/createSheet.xlsx", create = TRUE)
+    expect_error(createSheet(wb.xlsx, "'Invalid Sheet Name"), "IllegalArgumentException")
+    expect_error(createSheet(wb.xlsx, "Invalid Sheet Name'"), "IllegalArgumentException")
     expect_error(createSheet(wb.xlsx, "A very very very very very very very very long name"), "IllegalArgumentException")
+})
+
+test_that("createSheet works for valid sheet names in XLS and XLSX", {
+    wb.xls <- loadWorkbook("resources/createSheet.xls", create = TRUE)
+    wb.xlsx <- loadWorkbook("resources/createSheet.xlsx", create = TRUE)
     sheetName <- "My Sheet"
-    # createSheet should not throw an error for valid sheet names
+
     createSheet(wb.xls, sheetName)
     expect_true(existsSheet(wb.xls, sheetName))
+
     createSheet(wb.xlsx, sheetName)
     expect_true(existsSheet(wb.xlsx, sheetName))
-    # Creating an existing sheet should also not throw an error (it's a NOP)
-    createSheet(wb.xls, sheetName)
+})
+
+test_that("creating an existing sheet is a NOP in XLS and XLSX", {
+    wb.xls <- loadWorkbook("resources/createSheet.xls", create = TRUE)
+    wb.xlsx <- loadWorkbook("resources/createSheet.xlsx", create = TRUE)
+    sheetName <- "My Sheet"
+
+    createSheet(wb.xls, sheetName) # First time
     expect_true(existsSheet(wb.xls, sheetName))
-    createSheet(wb.xlsx, sheetName)
+    createSheet(wb.xls, sheetName) # Second time
+    expect_true(existsSheet(wb.xls, sheetName))
+
+    createSheet(wb.xlsx, sheetName) # First time
+    expect_true(existsSheet(wb.xlsx, sheetName))
+    createSheet(wb.xlsx, sheetName) # Second time
     expect_true(existsSheet(wb.xlsx, sheetName))
 })

--- a/tests/testthat/test.workbook.existsName.R
+++ b/tests/testthat/test.workbook.existsName.R
@@ -1,11 +1,5 @@
-test_that("test.workbook.existsName", {
-    wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx",
-        create = FALSE
-    )
-    # Global names
+test_that("existsName identifies global names in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
     res_xls_AA <- existsName(wb.xls, "AA")
     expect_true(res_xls_AA)
     xls_AA_scope <- attr(res_xls_AA, "worksheetScope")
@@ -18,11 +12,17 @@ test_that("test.workbook.existsName", {
     expect_true(res_xls_CC)
     xls_CC_scope <- attr(res_xls_CC, "worksheetScope")
     expect_true(is.null(xls_CC_scope) || xls_CC_scope == "")
+})
 
+test_that("existsName identifies non-existent and illegal names in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
     expect_false(existsName(wb.xls, "DD"))
     expect_false(existsName(wb.xls, "'illegal name"))
     expect_false(existsName(wb.xls, "%&$$-^~@afk20 235-??a?"))
+})
 
+test_that("existsName identifies global names in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
     res_xlsx_AA <- existsName(wb.xlsx, "AA")
     expect_true(res_xlsx_AA)
     xlsx_AA_scope <- attr(res_xlsx_AA, "worksheetScope")
@@ -35,12 +35,17 @@ test_that("test.workbook.existsName", {
     expect_true(res_xlsx_CC)
     xlsx_CC_scope <- attr(res_xlsx_CC, "worksheetScope")
     expect_true(is.null(xlsx_CC_scope) || xlsx_CC_scope == "")
+})
 
+test_that("existsName identifies non-existent and illegal names in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
     expect_false(existsName(wb.xlsx, "DD"))
     expect_false(existsName(wb.xlsx, "'illegal name"))
     expect_false(existsName(wb.xlsx, "%&$$-^~@afk20 235-??a?"))
+})
 
-    # Sheet-scoped names
+test_that("existsName identifies sheet-scoped names in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
     res_xls_AA_1 <- existsName(wb.xls, "AA_1")
     expect_true(res_xls_AA_1)
     if (isTRUE(getOption("XLConnect.setCustomAttributes"))) {
@@ -51,7 +56,10 @@ test_that("test.workbook.existsName", {
     if (isTRUE(getOption("XLConnect.setCustomAttributes"))) {
         expect_equal(attr(res_xls_BB_1, "worksheetScope"), "BBB")
     }
+})
 
+test_that("existsName identifies sheet-scoped names in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
     res_xlsx_AA_1 <- existsName(wb.xlsx, "AA_1")
     expect_true(res_xlsx_AA_1)
     if (isTRUE(getOption("XLConnect.setCustomAttributes"))) {
@@ -62,7 +70,11 @@ test_that("test.workbook.existsName", {
     if (isTRUE(getOption("XLConnect.setCustomAttributes"))) {
         expect_equal(attr(res_xlsx_BB_1, "worksheetScope"), "BBB")
     }
+})
 
+test_that("existsName works when XLConnect.setCustomAttributes is FALSE", {
+    wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
+    wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
     options(XLConnect.setCustomAttributes = FALSE)
     expect_true(existsName(wb.xls, "AA_1"))
     expect_true(existsName(wb.xls, "BB_1"))

--- a/tests/testthat/test.workbook.extraction.R
+++ b/tests/testthat/test.workbook.extraction.R
@@ -1,40 +1,47 @@
-test_that("test.workbook.extraction", {
-    wb.xls <- loadWorkbook("resources/testWorkbookExtractionOperators.xls",
-        create = TRUE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookExtractionOperators.xlsx",
-        create = TRUE
-    )
+test_that("extraction operator works for XLS worksheets", {
+    wb.xls <- loadWorkbook("resources/testWorkbookExtractionOperators.xls", create = TRUE)
     wb.xls["mtcars1"] <- mtcars
     expect_true("mtcars1" %in% getSheets(wb.xls))
     expect_equal(33, as.vector(getLastRow(wb.xls, "mtcars1")))
     wb.xls["mtcars2", startRow = 6, startCol = 11, header = FALSE] <- mtcars
     expect_true("mtcars2" %in% getSheets(wb.xls))
     expect_equal(37, as.vector(getLastRow(wb.xls, "mtcars2")))
+    expect_equal(c(32, 11), dim(wb.xls["mtcars1"]))
+    expect_equal(c(31, 11), dim(wb.xls["mtcars2"]))
+})
+
+test_that("extraction operator works for XLSX worksheets", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookExtractionOperators.xlsx", create = TRUE)
     wb.xlsx["mtcars1"] <- mtcars
     expect_true("mtcars1" %in% getSheets(wb.xlsx))
     expect_equal(33, as.vector(getLastRow(wb.xlsx, "mtcars1")))
     wb.xlsx["mtcars2", startRow = 6, startCol = 11, header = FALSE] <- mtcars
     expect_true("mtcars2" %in% getSheets(wb.xlsx))
     expect_equal(37, as.vector(getLastRow(wb.xlsx, "mtcars2")))
-    expect_equal(c(32, 11), dim(wb.xls["mtcars1"]))
-    expect_equal(c(31, 11), dim(wb.xls["mtcars2"]))
     expect_equal(c(32, 11), dim(wb.xlsx["mtcars1"]))
     expect_equal(c(31, 11), dim(wb.xlsx["mtcars2"]))
+})
+
+test_that("extraction operator works for XLS named regions", {
+    wb.xls <- loadWorkbook("resources/testWorkbookExtractionOperators.xls", create = TRUE)
     wb.xls[["mtcars3", "mtcars3!$B$7"]] <- mtcars
     expect_true("mtcars3" %in% getDefinedNames(wb.xls))
     expect_equal(39, as.vector(getLastRow(wb.xls, "mtcars3")))
     wb.xls[["mtcars4", "mtcars4!$D$8", rownames = "Car"]] <- mtcars
     expect_true("mtcars4" %in% getDefinedNames(wb.xls))
     expect_equal(40, as.vector(getLastRow(wb.xls, "mtcars4")))
+    expect_equal(c(32, 11), dim(wb.xls[["mtcars3"]]))
+    expect_equal(c(32, 12), dim(wb.xls[["mtcars4"]]))
+})
+
+test_that("extraction operator works for XLSX named regions", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookExtractionOperators.xlsx", create = TRUE)
     wb.xlsx[["mtcars3", "mtcars3!$B$7"]] <- mtcars
     expect_true("mtcars3" %in% getDefinedNames(wb.xlsx))
     expect_equal(39, as.vector(getLastRow(wb.xlsx, "mtcars3")))
     wb.xlsx[["mtcars4", "mtcars4!$D$8", rownames = "Car"]] <- mtcars
     expect_true("mtcars4" %in% getDefinedNames(wb.xlsx))
     expect_equal(40, as.vector(getLastRow(wb.xlsx, "mtcars4")))
-    expect_equal(c(32, 11), dim(wb.xls[["mtcars3"]]))
-    expect_equal(c(32, 12), dim(wb.xls[["mtcars4"]]))
     expect_equal(c(32, 11), dim(wb.xlsx[["mtcars3"]]))
     expect_equal(c(32, 12), dim(wb.xlsx[["mtcars4"]]))
 })

--- a/tests/testthat/test.workbook.getBoundingBox.R
+++ b/tests/testthat/test.workbook.getBoundingBox.R
@@ -1,53 +1,69 @@
-test_that("test.workbook.getBoundingBox", {
-    wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx",
-        create = FALSE
-    )
+test_that("getBoundingBox returns correct dimensions for a single sheet in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
     dim1 <- matrix(c(17, 6, 25, 9), dimnames = list(c(), c("Test5")))
-    dim2 <- matrix(c(17, 7, 24, 9), dimnames = list(c(), c("Test5")))
-    dim3 <- matrix(c(17, 7, 25, 9), dimnames = list(c(), c("Test5")))
-    dim4 <- matrix(c(17, 6, 24, 9), dimnames = list(c(), c("Test5")))
-    dim5 <- matrix(c(11, 6, 16, 9, 8, 4, 16, 7, 17, 6, 25, 9),
-        ncol = 3, dimnames = list(c(), c("Test1", "Test4", "Test5"))
-    )
     res <- getBoundingBox(wb.xls, sheet = "Test5")
     expect_equal(dim1, res)
+})
+
+test_that("getBoundingBox returns correct dimensions for a single sheet in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
+    dim1 <- matrix(c(17, 6, 25, 9), dimnames = list(c(), c("Test5")))
     res <- getBoundingBox(wb.xlsx, sheet = "Test5")
     expect_equal(dim1, res)
-    res <- getBoundingBox(wb.xls,
-        sheet = "Test5", startRow = 17,
-        startCol = 7, endRow = 24, endCol = 9
-    )
+})
+
+test_that("getBoundingBox returns correct dimensions for a specified region in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
+    dim2 <- matrix(c(17, 7, 24, 9), dimnames = list(c(), c("Test5")))
+    res <- getBoundingBox(wb.xls, sheet = "Test5", startRow = 17, startCol = 7, endRow = 24, endCol = 9)
     expect_equal(dim2, res)
-    res <- getBoundingBox(wb.xlsx,
-        sheet = "Test5", startRow = 17,
-        startCol = 7, endRow = 24, endCol = 9
-    )
+})
+
+test_that("getBoundingBox returns correct dimensions for a specified region in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
+    dim2 <- matrix(c(17, 7, 24, 9), dimnames = list(c(), c("Test5")))
+    res <- getBoundingBox(wb.xlsx, sheet = "Test5", startRow = 17, startCol = 7, endRow = 24, endCol = 9)
     expect_equal(dim2, res)
-    res <- getBoundingBox(wb.xls,
-        sheet = "Test5", startCol = 7,
-        endCol = 9
-    )
+})
+
+test_that("getBoundingBox returns correct dimensions with start and end columns in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
+    dim3 <- matrix(c(17, 7, 25, 9), dimnames = list(c(), c("Test5")))
+    res <- getBoundingBox(wb.xls, sheet = "Test5", startCol = 7, endCol = 9)
     expect_equal(dim3, res)
-    res <- getBoundingBox(wb.xlsx,
-        sheet = "Test5", startCol = 7,
-        endCol = 9
-    )
+})
+
+test_that("getBoundingBox returns correct dimensions with start and end columns in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
+    dim3 <- matrix(c(17, 7, 25, 9), dimnames = list(c(), c("Test5")))
+    res <- getBoundingBox(wb.xlsx, sheet = "Test5", startCol = 7, endCol = 9)
     expect_equal(dim3, res)
+})
+
+test_that("getBoundingBox returns correct dimensions with end row in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
+    dim4 <- matrix(c(17, 6, 24, 9), dimnames = list(c(), c("Test5")))
     res <- getBoundingBox(wb.xls, sheet = "Test5", endRow = 24)
     expect_equal(dim4, res)
+})
+
+test_that("getBoundingBox returns correct dimensions with end row in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
+    dim4 <- matrix(c(17, 6, 24, 9), dimnames = list(c(), c("Test5")))
     res <- getBoundingBox(wb.xlsx, sheet = "Test5", endRow = 24)
     expect_equal(dim4, res)
-    res <- getBoundingBox(wb.xls, sheet = c(
-        "Test1", "Test4",
-        "Test5"
-    ))
+})
+
+test_that("getBoundingBox returns correct dimensions for multiple sheets in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
+    dim5 <- matrix(c(11, 6, 16, 9, 8, 4, 16, 7, 17, 6, 25, 9), ncol = 3, dimnames = list(c(), c("Test1", "Test4", "Test5")))
+    res <- getBoundingBox(wb.xls, sheet = c("Test1", "Test4", "Test5"))
     expect_equal(dim5, res)
-    res <- getBoundingBox(wb.xlsx, sheet = c(
-        "Test1", "Test4",
-        "Test5"
-    ))
+})
+
+test_that("getBoundingBox returns correct dimensions for multiple sheets in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
+    dim5 <- matrix(c(11, 6, 16, 9, 8, 4, 16, 7, 17, 6, 25, 9), ncol = 3, dimnames = list(c(), c("Test1", "Test4", "Test5")))
+    res <- getBoundingBox(wb.xlsx, sheet = c("Test1", "Test4", "Test5"))
     expect_equal(dim5, res)
 })

--- a/tests/testthat/test.workbook.getDefinedNames.R
+++ b/tests/testthat/test.workbook.getDefinedNames.R
@@ -1,52 +1,43 @@
-test_that("test.workbook.getDefinedNames", {
-    wb.xls <- loadWorkbook("resources/testWorkbookDefinedNames.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookDefinedNames.xlsx",
-        create = FALSE
-    )
-    expectedNamesValidOnly <- c(
-        "FirstName", "SecondName", "FourthName",
-        "FifthName"
-    )
-    expectedNamesAll <- c(
-        "FirstName", "SecondName", "ThirdName",
-        "FourthName", "FifthName"
-    )
+test_that("getDefinedNames returns valid names only in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookDefinedNames.xls", create = FALSE)
+    expectedNamesValidOnly <- c("FirstName", "SecondName", "FourthName", "FifthName")
     definedNames <- getDefinedNames(wb.xls, validOnly = TRUE)
-    expect_true(length(setdiff(expectedNamesValidOnly, definedNames)) ==
-        0 && length(setdiff(definedNames, expectedNamesValidOnly)) ==
-        0)
+    expect_true(setequal(expectedNamesValidOnly, definedNames))
+})
+
+test_that("getDefinedNames returns all names in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookDefinedNames.xls", create = FALSE)
+    expectedNamesAll <- c("FirstName", "SecondName", "ThirdName", "FourthName", "FifthName")
     definedNames <- getDefinedNames(wb.xls, validOnly = FALSE)
-    expect_true(length(setdiff(expectedNamesAll, definedNames)) ==
-        0 && length(setdiff(definedNames, expectedNamesAll)) ==
-        0)
+    expect_true(setequal(expectedNamesAll, definedNames))
+})
+
+test_that("getDefinedNames returns valid names only in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookDefinedNames.xlsx", create = FALSE)
+    expectedNamesValidOnly <- c("FirstName", "SecondName", "FourthName", "FifthName")
     definedNames <- getDefinedNames(wb.xlsx, validOnly = TRUE)
-    expect_true(length(setdiff(expectedNamesValidOnly, definedNames)) ==
-        0 && length(setdiff(definedNames, expectedNamesValidOnly)) ==
-        0)
+    expect_true(setequal(expectedNamesValidOnly, definedNames))
+})
+
+test_that("getDefinedNames returns all names in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookDefinedNames.xlsx", create = FALSE)
+    expectedNamesAll <- c("FirstName", "SecondName", "ThirdName", "FourthName", "FifthName")
     definedNames <- getDefinedNames(wb.xlsx, validOnly = FALSE)
-    expect_true(length(setdiff(expectedNamesAll, definedNames)) ==
-        0 && length(setdiff(definedNames, expectedNamesAll)) ==
-        0)
-    wb.xls <- loadWorkbook("resources/testWorkbookGetDefinedNamesScoped.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookGetDefinedNamesScoped.xlsx",
-        create = FALSE
-    )
+    expect_true(setequal(expectedNamesAll, definedNames))
+})
+
+test_that("getDefinedNames returns scoped names correctly in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookGetDefinedNamesScoped.xls", create = FALSE)
     expectedNames <- c("ScopedName1", "ScopedName2")
     expectedScopes <- c("scoped_1", "scoped_2")
     res_xls <- getDefinedNames(wb.xls, validOnly = TRUE)
     expect_true(setequal(res_xls, expectedNames))
-    expect_true(setequal(
-        attributes(res_xls)$worksheetScope,
-        expectedScopes
-    ))
+})
+
+test_that("getDefinedNames returns scoped names correctly in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookGetDefinedNamesScoped.xlsx", create = FALSE)
+    expectedNames <- c("ScopedName1", "ScopedName2")
+    expectedScopes <- c("scoped_1", "scoped_2")
     res_xlsx <- getDefinedNames(wb.xlsx, validOnly = TRUE)
     expect_true(setequal(res_xlsx, expectedNames))
-    expect_true(setequal(
-        attributes(res_xlsx)$worksheetScope,
-        expectedScopes
-    ))
 })

--- a/tests/testthat/test.workbook.getReferenceCoordinates.R
+++ b/tests/testthat/test.workbook.getReferenceCoordinates.R
@@ -1,14 +1,19 @@
-test_that("test.workbook.getReferenceCoordinates", {
-    wb.xls <- loadWorkbook("resources/testWorkbookReferenceFormula.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookReferenceFormula.xlsx",
-        create = FALSE
-    )
-    expect_true(all(getReferenceCoordinatesForName(wb.xls, "FirstName") ==
-        matrix(c(1, 1, 1, 1), nrow = 2, byrow = TRUE)))
+test_that("getReferenceCoordinatesForName returns correct coordinates for a valid name in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookReferenceFormula.xls", create = FALSE)
+    expect_true(all(getReferenceCoordinatesForName(wb.xls, "FirstName") == matrix(c(1, 1, 1, 1), nrow = 2, byrow = TRUE)))
+})
+
+test_that("getReferenceCoordinatesForName throws an error for a non-existent name in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookReferenceFormula.xls", create = FALSE)
     expect_error(getReferenceCoordinatesForName(wb.xls, "NonExistentName"))
-    expect_true(all(getReferenceCoordinatesForName(wb.xlsx, "FirstName") ==
-        matrix(c(1, 1, 1, 1), nrow = 2, byrow = TRUE)))
+})
+
+test_that("getReferenceCoordinatesForName returns correct coordinates for a valid name in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReferenceFormula.xlsx", create = FALSE)
+    expect_true(all(getReferenceCoordinatesForName(wb.xlsx, "FirstName") == matrix(c(1, 1, 1, 1), nrow = 2, byrow = TRUE)))
+})
+
+test_that("getReferenceCoordinatesForName throws an error for a non-existent name in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReferenceFormula.xlsx", create = FALSE)
     expect_error(getReferenceCoordinatesForName(wb.xlsx, "NonExistentName"))
 })

--- a/tests/testthat/test.workbook.getReferenceFormula.R
+++ b/tests/testthat/test.workbook.getReferenceFormula.R
@@ -21,23 +21,23 @@ test_that("test.workbook.getReferenceFormula", {
     expect_equal(expect_formula, getReferenceFormula(
         wb.xls,
         "FirstName"
-    ),  ignore_attr = TRUE)
+    ))
     expect_formula <- "#REF!"
     attributes(expect_formula) <- list(worksheetScope = "")
     expect_equal(expect_formula, substring(getReferenceFormula(
         wb.xls,
         "SecondName"
-    ), 1, 5),  ignore_attr = TRUE)
+    ), 1, 5))
     expect_formula <- "Tabelle1!$A$1"
     attributes(expect_formula) <- list(worksheetScope = "")
     expect_equal(expect_formula, getReferenceFormula(
         wb.xlsx,
         "FirstName"
-    ),  ignore_attr = TRUE)
+    ))
     expect_formula <- "#REF!"
     attributes(expect_formula) <- list(worksheetScope = "")
     expect_equal(expect_formula, substring(getReferenceFormula(
         wb.xlsx,
         "SecondName"
-    ), 1, 5),  ignore_attr = TRUE)
+    ), 1, 5))
 })

--- a/tests/testthat/test.workbook.getReferenceFormula.R
+++ b/tests/testthat/test.workbook.getReferenceFormula.R
@@ -21,23 +21,23 @@ test_that("test.workbook.getReferenceFormula", {
     expect_equal(expect_formula, getReferenceFormula(
         wb.xls,
         "FirstName"
-    ))
+    ),  ignore_attr = TRUE)
     expect_formula <- "#REF!"
     attributes(expect_formula) <- list(worksheetScope = "")
     expect_equal(expect_formula, substring(getReferenceFormula(
         wb.xls,
         "SecondName"
-    ), 1, 5))
+    ), 1, 5),  ignore_attr = TRUE)
     expect_formula <- "Tabelle1!$A$1"
     attributes(expect_formula) <- list(worksheetScope = "")
     expect_equal(expect_formula, getReferenceFormula(
         wb.xlsx,
         "FirstName"
-    ))
+    ),  ignore_attr = TRUE)
     expect_formula <- "#REF!"
     attributes(expect_formula) <- list(worksheetScope = "")
     expect_equal(expect_formula, substring(getReferenceFormula(
         wb.xlsx,
         "SecondName"
-    ), 1, 5))
+    ), 1, 5),  ignore_attr = TRUE)
 })

--- a/tests/testthat/test.workbook.getSheetPos.R
+++ b/tests/testthat/test.workbook.getSheetPos.R
@@ -1,28 +1,25 @@
-test_that("test.workbook.getSheetPos", {
-    wb.xls <- loadWorkbook("resources/testWorkbookGetSheetPos.xls",
-        create = TRUE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookGetSheetPos.xlsx",
-        create = TRUE
-    )
+test_that("getSheetPos returns correct positions for existing sheets in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookGetSheetPos.xls", create = TRUE)
     createSheet(wb.xls, c("Sheet 1", "Sheet 2", "Sheet 3", "Sheet 4"))
+    expected <- c(`Sheet 3` = 3, `Sheet 2` = 2, `Sheet 4` = 4, `Sheet 1` = 1)
+    expect_equal(expected, getSheetPos(wb.xls, c("Sheet 3", "Sheet 2", "Sheet 4", "Sheet 1")))
+})
+
+test_that("getSheetPos returns correct positions for existing sheets in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookGetSheetPos.xlsx", create = TRUE)
     createSheet(wb.xlsx, c("Sheet 1", "Sheet 2", "Sheet 3", "Sheet 4"))
-    expect_equal(c(
-        `Sheet 3` = 3, `Sheet 2` = 2, `Sheet 4` = 4,
-        `Sheet 1` = 1
-    ), getSheetPos(wb.xls, c(
-        "Sheet 3", "Sheet 2",
-        "Sheet 4", "Sheet 1"
-    )))
-    expect_equal(c(
-        `Sheet 3` = 3, `Sheet 2` = 2, `Sheet 4` = 4,
-        `Sheet 1` = 1
-    ), getSheetPos(wb.xlsx, c(
-        "Sheet 3", "Sheet 2",
-        "Sheet 4", "Sheet 1"
-    )))
+    expected <- c(`Sheet 3` = 3, `Sheet 2` = 2, `Sheet 4` = 4, `Sheet 1` = 1)
+    expect_equal(expected, getSheetPos(wb.xlsx, c("Sheet 3", "Sheet 2", "Sheet 4", "Sheet 1")))
+})
+
+test_that("getSheetPos handles non-existing and illegal sheet names in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookGetSheetPos.xls", create = TRUE)
     expect_equal(c(NotExisting = 0), getSheetPos(wb.xls, "NotExisting"))
     expect_equal(0, as.vector(getSheetPos(wb.xls, "%#?%+?[-")))
+})
+
+test_that("getSheetPos handles non-existing and illegal sheet names in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookGetSheetPos.xlsx", create = TRUE)
     expect_equal(c(NotExisting = 0), getSheetPos(wb.xlsx, "NotExisting"))
     expect_equal(0, as.vector(getSheetPos(wb.xlsx, "%#?%+?[-")))
 })

--- a/tests/testthat/test.workbook.getTables.R
+++ b/tests/testthat/test.workbook.getTables.R
@@ -1,12 +1,22 @@
-test_that("test.workbook.getTables", {
-    wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx",
-        create = FALSE
-    )
+test_that("getTables returns a simplified list of tables", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
     res <- getTables(wb.xlsx, sheet = "Test", simplify = TRUE)
     expect_equal("TestTable1", res)
+})
+
+test_that("getTables returns a nested list of tables", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
     res <- getTables(wb.xlsx, sheet = "Test", simplify = FALSE)
     expect_equal(list(Test = "TestTable1"), res)
+})
+
+test_that("getTables returns an empty list for a sheet with no tables", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
     res <- getTables(wb.xlsx, sheet = "NoTableHere", simplify = TRUE)
     expect_equal(character(0), res)
+})
+
+test_that("getTables throws an error for a non-existent sheet", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
     expect_error(getTables(wb.xlsx, sheet = "DoesNotExist"))
 })

--- a/tests/testthat/test.workbook.isSheetHidden.R
+++ b/tests/testthat/test.workbook.isSheetHidden.R
@@ -1,29 +1,44 @@
-test_that("test.workbook.isSheetHidden", {
-    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx",
-        create = FALSE
-    )
+test_that("isSheetHidden identifies hidden sheets correctly in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
     expect_true(isSheetHidden(wb.xls, 2))
     expect_true(isSheetHidden(wb.xls, "BBB"))
+})
+
+test_that("isSheetHidden identifies non-hidden sheets correctly in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
     expect_false(isSheetHidden(wb.xls, 1))
     expect_false(isSheetHidden(wb.xls, "AAA"))
     expect_false(isSheetHidden(wb.xls, 3))
     expect_false(isSheetHidden(wb.xls, "CCC"))
     expect_false(isSheetHidden(wb.xls, 4))
     expect_false(isSheetHidden(wb.xls, "DDD"))
+})
+
+test_that("isSheetHidden throws errors for invalid sheets in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
+    expect_error(isSheetHidden(wb.xls, 200))
+    expect_error(isSheetHidden(wb.xls, "Sheet does not exist"))
+    expect_error(isSheetHidden(wb.xls, "'Illegal sheet name"))
+})
+
+test_that("isSheetHidden identifies hidden sheets correctly in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
     expect_true(isSheetHidden(wb.xlsx, 2))
     expect_true(isSheetHidden(wb.xlsx, "BBB"))
+})
+
+test_that("isSheetHidden identifies non-hidden sheets correctly in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
     expect_false(isSheetHidden(wb.xlsx, 1))
     expect_false(isSheetHidden(wb.xlsx, "AAA"))
     expect_false(isSheetHidden(wb.xlsx, 3))
     expect_false(isSheetHidden(wb.xlsx, "CCC"))
     expect_false(isSheetHidden(wb.xlsx, 4))
     expect_false(isSheetHidden(wb.xlsx, "DDD"))
-    expect_error(isSheetHidden(wb.xls, 200))
-    expect_error(isSheetHidden(wb.xls, "Sheet does not exist"))
-    expect_error(isSheetHidden(wb.xls, "'Illegal sheet name"))
+})
+
+test_that("isSheetHidden throws errors for invalid sheets in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
     expect_error(isSheetHidden(wb.xlsx, 200))
     expect_error(isSheetHidden(wb.xlsx, "Sheet does not exist"))
     expect_error(isSheetHidden(wb.xlsx, "'Illegal sheet name"))

--- a/tests/testthat/test.workbook.isSheetVeryHidden.R
+++ b/tests/testthat/test.workbook.isSheetVeryHidden.R
@@ -1,29 +1,44 @@
-test_that("test.workbook.isSheetVeryHidden", {
-    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx",
-        create = FALSE
-    )
+test_that("isSheetVeryHidden identifies very hidden sheets correctly in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
     expect_true(isSheetVeryHidden(wb.xls, 4))
     expect_true(isSheetVeryHidden(wb.xls, "DDD"))
+})
+
+test_that("isSheetVeryHidden identifies non-very hidden sheets correctly in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
     expect_false(isSheetVeryHidden(wb.xls, 1))
     expect_false(isSheetVeryHidden(wb.xls, "AAA"))
     expect_false(isSheetVeryHidden(wb.xls, 2))
     expect_false(isSheetVeryHidden(wb.xls, "BBB"))
     expect_false(isSheetVeryHidden(wb.xls, 3))
     expect_false(isSheetVeryHidden(wb.xls, "CCC"))
+})
+
+test_that("isSheetVeryHidden throws errors for invalid sheets in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
+    expect_error(isSheetVeryHidden(wb.xls, 200))
+    expect_error(isSheetVeryHidden(wb.xls, "Sheet does not exist"))
+    expect_error(isSheetVeryHidden(wb.xls, "'Illegal sheet name"))
+})
+
+test_that("isSheetVeryHidden identifies very hidden sheets correctly in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
     expect_true(isSheetVeryHidden(wb.xlsx, 4))
     expect_true(isSheetVeryHidden(wb.xlsx, "DDD"))
+})
+
+test_that("isSheetVeryHidden identifies non-very hidden sheets correctly in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
     expect_false(isSheetVeryHidden(wb.xlsx, 1))
     expect_false(isSheetVeryHidden(wb.xlsx, "AAA"))
     expect_false(isSheetVeryHidden(wb.xlsx, 2))
     expect_false(isSheetVeryHidden(wb.xlsx, "BBB"))
     expect_false(isSheetVeryHidden(wb.xlsx, 3))
     expect_false(isSheetVeryHidden(wb.xlsx, "CCC"))
-    expect_error(isSheetVeryHidden(wb.xls, 200))
-    expect_error(isSheetVeryHidden(wb.xls, "Sheet does not exist"))
-    expect_error(isSheetVeryHidden(wb.xls, "'Illegal sheet name"))
+})
+
+test_that("isSheetVeryHidden throws errors for invalid sheets in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
     expect_error(isSheetVeryHidden(wb.xlsx, 200))
     expect_error(isSheetVeryHidden(wb.xlsx, "Sheet does not exist"))
     expect_error(isSheetVeryHidden(wb.xlsx, "'Illegal sheet name"))

--- a/tests/testthat/test.workbook.onErrorCell.R
+++ b/tests/testthat/test.workbook.onErrorCell.R
@@ -13,7 +13,7 @@ test_that("test.workbook.onErrorCell", {
         stringsAsFactors = FALSE
     )
     attr(target, "worksheetScope") <- ""
-    expect_equal(target, res, ignore_attr = TRUE)
+    expect_equal(target, res)
     expect_warning(res <- try(readNamedRegion(wb.xls, name = "BB")), "Error detected in cell")
     expect_false(is(res, "try-error"))
     target <- data.frame(
@@ -21,7 +21,7 @@ test_that("test.workbook.onErrorCell", {
         stringsAsFactors = FALSE
     )
     attr(target, "worksheetScope") <- ""
-    expect_equal(target, res, ignore_attr = TRUE)
+    expect_equal(target, res)
     options(XLConnect.setCustomAttributes = FALSE)
     expect_warning(res <- try(readNamedRegion(wb.xls, name = "CC")), "Error detected in cell")
     expect_false(is(res, "try-error"))

--- a/tests/testthat/test.workbook.readTable.R
+++ b/tests/testthat/test.workbook.readTable.R
@@ -1,18 +1,10 @@
-test_that("test.workbook.readTable", {
-    wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx",
-        create = FALSE
-    )
+test_that("readTable reads a table from an XLSX file", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
     checkDf <- data.frame(
-        NumericColumn = c(
-            -23.63, NA, NA, 5.8,
-            3
-        ), StringColumn = c("Hello", NA, NA, NA, "World"), BooleanColumn = c(
-            TRUE,
-            FALSE, FALSE, NA, NA
-        ), DateTimeColumn = as.POSIXct(c(
-            NA,
-            NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07"
-        )),
+        NumericColumn = c(-23.63, NA, NA, 5.8, 3),
+        StringColumn = c("Hello", NA, NA, NA, "World"),
+        BooleanColumn = c(TRUE, FALSE, FALSE, NA, NA),
+        DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
         stringsAsFactors = F
     )
     res <- readTable(wb.xlsx, sheet = "Test", table = "TestTable1")

--- a/tests/testthat/test.workbook.readWorksheet.R
+++ b/tests/testthat/test.workbook.readWorksheet.R
@@ -1,4 +1,5 @@
-test_that("reading basic worksheets by index and name works", {
+test_that("reading basic worksheets by index and name works in XLS", {
+    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
     common_checkDf <- data.frame(
         NumericColumn = c(-23.63, NA, NA, 5.8, 3),
         StringColumn = c("Hello", NA, NA, NA, "World"),
@@ -6,19 +7,25 @@ test_that("reading basic worksheets by index and name works", {
         DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
         stringsAsFactors = FALSE
     )
-
-    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
-    # XLS
     expect_equal(common_checkDf, readWorksheet(wb.xls, 1), info = "XLS: Read sheet 1 by index")
     expect_equal(common_checkDf, readWorksheet(wb.xls, "Test1"), info = "XLS: Read sheet 'Test1' by name")
-    # XLSX
+})
+
+test_that("reading basic worksheets by index and name works in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    common_checkDf <- data.frame(
+        NumericColumn = c(-23.63, NA, NA, 5.8, 3),
+        StringColumn = c("Hello", NA, NA, NA, "World"),
+        BooleanColumn = c(TRUE, FALSE, FALSE, NA, NA),
+        DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
+        stringsAsFactors = FALSE
+    )
     expect_equal(common_checkDf, readWorksheet(wb.xlsx, 1), info = "XLSX: Read sheet 1 by index")
     expect_equal(common_checkDf, readWorksheet(wb.xlsx, "Test1"), info = "XLSX: Read sheet 'Test1' by name")
 })
 
-test_that("reading specific regions (startRow/Col, endRow/Col, region string) works", {
+test_that("reading specific regions works in XLS", {
+    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
     common_checkDf <- data.frame(
         NumericColumn = c(-23.63, NA, NA, 5.8, 3),
         StringColumn = c("Hello", NA, NA, NA, "World"),
@@ -26,48 +33,51 @@ test_that("reading specific regions (startRow/Col, endRow/Col, region string) wo
         DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
         stringsAsFactors = FALSE
     )
-
-    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
-    # Using startRow/Col, endRow/Col
     expect_equal(common_checkDf, readWorksheet(wb.xls, 2, startRow = 17, startCol = 6, endRow = 22, endCol = 9, header = TRUE), info = "XLS: Specific area")
-    expect_equal(common_checkDf, readWorksheet(wb.xlsx, "Test2", startRow = 17, startCol = 6, endRow = 22, endCol = 9, header = TRUE), info = "XLSX: Specific area by name")
-
-    # Using negative endRow/Col
     expected_neg_end <- common_checkDf[-nrow(common_checkDf) + 0:1, -ncol(common_checkDf)]
     expect_equal(expected_neg_end, readWorksheet(wb.xls, "Test2", startRow = 17, startCol = 6, endRow = -2, endCol = -1, header = TRUE), info = "XLS: Negative endRow/Col")
-    expect_equal(expected_neg_end, readWorksheet(wb.xlsx, "Test2", startRow = 17, startCol = 6, endRow = -2, endCol = -1, header = TRUE), info = "XLSX: Negative endRow/Col")
-
-    # Using region string
     expect_equal(common_checkDf, readWorksheet(wb.xls, 2, region = "F17:I22", header = TRUE), info = "XLS: Region string")
-    expect_equal(common_checkDf, readWorksheet(wb.xlsx, "Test2", region = "F17:I22", header = TRUE), info = "XLSX: Region string by name")
-
-    # Region string with other params (region should take precedence)
     expect_equal(common_checkDf, readWorksheet(wb.xls, 2, region = "F17:I22", startRow = 88, endCol = 45, header = TRUE), info = "XLS: Region string with other params")
+})
+
+test_that("reading specific regions works in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    common_checkDf <- data.frame(
+        NumericColumn = c(-23.63, NA, NA, 5.8, 3),
+        StringColumn = c("Hello", NA, NA, NA, "World"),
+        BooleanColumn = c(TRUE, FALSE, FALSE, NA, NA),
+        DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
+        stringsAsFactors = FALSE
+    )
+    expect_equal(common_checkDf, readWorksheet(wb.xlsx, "Test2", startRow = 17, startCol = 6, endRow = 22, endCol = 9, header = TRUE), info = "XLSX: Specific area by name")
+    expected_neg_end <- common_checkDf[-nrow(common_checkDf) + 0:1, -ncol(common_checkDf)]
+    expect_equal(expected_neg_end, readWorksheet(wb.xlsx, "Test2", startRow = 17, startCol = 6, endRow = -2, endCol = -1, header = TRUE), info = "XLSX: Negative endRow/Col")
+    expect_equal(common_checkDf, readWorksheet(wb.xlsx, "Test2", region = "F17:I22", header = TRUE), info = "XLSX: Region string by name")
     expect_equal(common_checkDf, readWorksheet(wb.xlsx, "Test2", region = "F17:I22", startRow = 88, endCol = 45, header = TRUE), info = "XLSX: Region string with other params by name")
 })
 
-test_that("handling of non-existent sheets and empty sheets is correct", {
+test_that("handling of non-existent and empty sheets is correct in XLS", {
     wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
     expect_error(readWorksheet(wb.xls, 23), info = "XLS: Non-existent sheet index")
     expect_error(readWorksheet(wb.xls, "SheetDoesNotExist"), info = "XLS: Non-existent sheet name")
-    expect_error(readWorksheet(wb.xlsx, 23), info = "XLSX: Non-existent sheet index")
-    expect_error(readWorksheet(wb.xlsx, "SheetDoesNotExist"), info = "XLSX: Non-existent sheet name")
-
     res_xls_3 <- suppressMessages(readWorksheet(wb.xls, 3))
     expect_equal(data.frame(), res_xls_3, info = "XLS: Empty sheet by index (Test3)")
     res_xls_Test3 <- suppressMessages(readWorksheet(wb.xls, "Test3"))
     expect_equal(data.frame(), res_xls_Test3, info = "XLS: Empty sheet by name (Test3)")
+})
+
+test_that("handling of non-existent and empty sheets is correct in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    expect_error(readWorksheet(wb.xlsx, 23), info = "XLSX: Non-existent sheet index")
+    expect_error(readWorksheet(wb.xlsx, "SheetDoesNotExist"), info = "XLSX: Non-existent sheet name")
     res_xlsx_3 <- suppressMessages(readWorksheet(wb.xlsx, 3))
     expect_equal(data.frame(), res_xlsx_3, info = "XLSX: Empty sheet by index (Test3)")
     res_xlsx_Test3 <- suppressMessages(readWorksheet(wb.xlsx, "Test3"))
     expect_equal(data.frame(), res_xlsx_Test3, info = "XLSX: Empty sheet by name (Test3)")
 })
 
-test_that("reading sheets with NAs and varied data (Test4, Test5) works", {
+test_that("reading sheets with NAs and varied data works in XLS", {
+    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
     common_checkDf1 <- data.frame(
         A = c(1:2, NA, 3:6, NA), B = letters[1:8],
         C = c("z", "y", "x", "w", NA, "v", "u", NA), D = c(NA, 1:5, NA, NA),
@@ -78,40 +88,38 @@ test_that("reading sheets with NAs and varied data (Test4, Test5) works", {
         C = c("z", "y", "x", "w", NA, "v", "u", NA), D = c(NA, 1:5, NA, NA),
         stringsAsFactors = FALSE
     )
-    common_checkDf <- data.frame(
-        NumericColumn = c(-23.63, NA, NA, 5.8, 3),
-        StringColumn = c("Hello", NA, NA, NA, "World"),
-        BooleanColumn = c(TRUE, FALSE, FALSE, NA, NA),
-        DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
-        stringsAsFactors = FALSE
-    )
-
-    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
     expect_equal(common_checkDf1, readWorksheet(wb.xls, "Test4"), info = "XLS: Test4 sheet")
     expect_equal(common_checkDf2, readWorksheet(wb.xls, "Test5"), info = "XLS: Test5 sheet")
+    expected_test4_neg <- common_checkDf1[-nrow(common_checkDf1) + 0:3, -ncol(common_checkDf1) + 0:1]
+    expect_equal(expected_test4_neg, readWorksheet(wb.xls, "Test4", endRow = -4, endCol = -2), info = "XLS: Test4 negative endRow/Col")
+    expected_test5_neg <- common_checkDf2[-nrow(common_checkDf2) + 0:2, -ncol(common_checkDf2)]
+    expect_equal(expected_test5_neg, readWorksheet(wb.xls, "Test5", endRow = -3, endCol = -1), info = "XLS: Test5 negative endRow/Col")
+})
+
+test_that("reading sheets with NAs and varied data works in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    common_checkDf1 <- data.frame(
+        A = c(1:2, NA, 3:6, NA), B = letters[1:8],
+        C = c("z", "y", "x", "w", NA, "v", "u", NA), D = c(NA, 1:5, NA, NA),
+        stringsAsFactors = FALSE
+    )
+    common_checkDf2 <- data.frame(
+        A = c(rep(NA, 3), 3:6, NA), B = c(NA, letters[2:8]),
+        C = c("z", "y", "x", "w", NA, "v", "u", NA), D = c(NA, 1:5, NA, NA),
+        stringsAsFactors = FALSE
+    )
     expect_equal(common_checkDf1, readWorksheet(wb.xlsx, "Test4"), info = "XLSX: Test4 sheet")
     expect_equal(common_checkDf2, readWorksheet(wb.xlsx, "Test5"), info = "XLSX: Test5 sheet")
-
-    # Test4 with negative endRow/Col
-    expected_test4_neg <- common_checkDf1[-nrow(common_checkDf1) + 0:3, -ncol(common_checkDf) + 0:1] # Original used common_checkDf for ncol
-    expect_equal(expected_test4_neg, readWorksheet(wb.xls, "Test4", endRow = -4, endCol = -2), info = "XLS: Test4 negative endRow/Col")
+    expected_test4_neg <- common_checkDf1[-nrow(common_checkDf1) + 0:3, -ncol(common_checkDf1) + 0:1]
     expect_equal(expected_test4_neg, readWorksheet(wb.xlsx, "Test4", endRow = -4, endCol = -2), info = "XLSX: Test4 negative endRow/Col")
-
-    # Test5 with negative endRow/Col
-    expected_test5_neg <- common_checkDf2[-nrow(common_checkDf2) + 0:2, -ncol(common_checkDf)] # Original used common_checkDf for ncol
-    expect_equal(expected_test5_neg, readWorksheet(wb.xls, "Test5", endRow = -3, endCol = -1), info = "XLS: Test5 negative endRow/Col")
+    expected_test5_neg <- common_checkDf2[-nrow(common_checkDf2) + 0:2, -ncol(common_checkDf2)]
     expect_equal(expected_test5_neg, readWorksheet(wb.xlsx, "Test5", endRow = -3, endCol = -1), info = "XLSX: Test5 negative endRow/Col")
 })
 
-test_that("column type conversion (forceConversion = TRUE/FALSE) works", {
+test_that("column type conversion works in XLS", {
     wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
     col_types_spec <- c(XLC$DATA_TYPE.NUMERIC, XLC$DATA_TYPE.STRING, XLC$DATA_TYPE.BOOLEAN, XLC$DATA_TYPE.DATETIME)
     datetime_fmt <- "%d.%m.%Y %H:%M:%S"
-
     targetNoForce <- data.frame(
         AAA = c(NA, NA, NA, 780.9, NA),
         BBB = c("hello", "42.24", "true", NA, "11.01.1984 12:00:00"),
@@ -124,75 +132,94 @@ test_that("column type conversion (forceConversion = TRUE/FALSE) works", {
         CCC = c(TRUE, TRUE, NA, FALSE, FALSE), DDD = as.POSIXct(c("1984-01-11 12:00:00", "2012-02-06 16:15:23", "1984-01-11 12:00:00", NA, "1900-12-22 16:04:48")),
         stringsAsFactors = FALSE
     )
-
-    # forceConversion = FALSE
     res_xls_noforce <- readWorksheet(wb.xls, sheet = "Conversion", header = TRUE, colTypes = col_types_spec, forceConversion = FALSE, dateTimeFormat = datetime_fmt)
     expect_equal(targetNoForce, res_xls_noforce, info = "XLS: Conversion sheet, no force")
-    res_xlsx_noforce <- readWorksheet(wb.xlsx, sheet = "Conversion", header = TRUE, colTypes = col_types_spec, forceConversion = FALSE, dateTimeFormat = datetime_fmt)
-    expect_equal(targetNoForce, res_xlsx_noforce, info = "XLSX: Conversion sheet, no force")
-
-    # forceConversion = TRUE
     res_xls_force <- readWorksheet(wb.xls, sheet = "Conversion", header = TRUE, colTypes = col_types_spec, forceConversion = TRUE, dateTimeFormat = datetime_fmt)
     expect_equal(targetForce, res_xls_force, info = "XLS: Conversion sheet, force")
+})
+
+test_that("column type conversion works in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    col_types_spec <- c(XLC$DATA_TYPE.NUMERIC, XLC$DATA_TYPE.STRING, XLC$DATA_TYPE.BOOLEAN, XLC$DATA_TYPE.DATETIME)
+    datetime_fmt <- "%d.%m.%Y %H:%M:%S"
+    targetNoForce <- data.frame(
+        AAA = c(NA, NA, NA, 780.9, NA),
+        BBB = c("hello", "42.24", "true", NA, "11.01.1984 12:00:00"),
+        CCC = c(TRUE, NA, NA, NA, NA), DDD = as.POSIXct(c("1984-01-11 12:00:00", NA, NA, NA, NA)),
+        stringsAsFactors = FALSE
+    )
+    targetForce <- data.frame(
+        AAA = c(-14.65, NA, 11.7, 780.9, NA),
+        BBB = c("hello", "42.24", "true", NA, "11.01.1984 12:00:00"),
+        CCC = c(TRUE, TRUE, NA, FALSE, FALSE), DDD = as.POSIXct(c("1984-01-11 12:00:00", "2012-02-06 16:15:23", "1984-01-11 12:00:00", NA, "1900-12-22 16:04:48")),
+        stringsAsFactors = FALSE
+    )
+    res_xlsx_noforce <- readWorksheet(wb.xlsx, sheet = "Conversion", header = TRUE, colTypes = col_types_spec, forceConversion = FALSE, dateTimeFormat = datetime_fmt)
+    expect_equal(targetNoForce, res_xlsx_noforce, info = "XLSX: Conversion sheet, no force")
     res_xlsx_force <- readWorksheet(wb.xlsx, sheet = "Conversion", header = TRUE, colTypes = col_types_spec, forceConversion = TRUE, dateTimeFormat = datetime_fmt)
     expect_equal(targetForce, res_xlsx_force, info = "XLSX: Conversion sheet, force")
 })
 
-test_that("reading multiple sheets by name works", {
+test_that("reading multiple sheets by name works in XLS", {
     wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
     target_multi_sheet <- list(
         AAA = data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE),
         BBB = data.frame(D = 4:6, E = letters[4:6], F = c(FALSE, TRUE, TRUE), stringsAsFactors = FALSE)
     )
     expect_equal(target_multi_sheet, readWorksheet(wb.xls, sheet = c("AAA", "BBB"), header = TRUE), info = "XLS: Multi-sheet read")
+})
+
+test_that("reading multiple sheets by name works in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    target_multi_sheet <- list(
+        AAA = data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE),
+        BBB = data.frame(D = 4:6, E = letters[4:6], F = c(FALSE, TRUE, TRUE), stringsAsFactors = FALSE)
+    )
     expect_equal(target_multi_sheet, readWorksheet(wb.xlsx, sheet = c("AAA", "BBB"), header = TRUE), info = "XLSX: Multi-sheet read")
 })
 
-test_that("handling of variable names (check.names) works", {
+test_that("handling of variable names works in XLS", {
     wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
     target_var_names <- data.frame(
         `With whitespace` = 1:4, `And some other funky characters: _=?^~!$@#%§` = letters[1:4],
         check.names = FALSE, stringsAsFactors = FALSE
     )
     res_xls_varnames <- readWorksheet(wb.xls, sheet = "VariableNames", header = TRUE, check.names = FALSE)
     expect_equal(target_var_names, res_xls_varnames, info = "XLS: VariableNames sheet, check.names=FALSE")
+})
+
+test_that("handling of variable names works in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    target_var_names <- data.frame(
+        `With whitespace` = 1:4, `And some other funky characters: _=?^~!$@#%§` = letters[1:4],
+        check.names = FALSE, stringsAsFactors = FALSE
+    )
     res_xlsx_varnames <- readWorksheet(wb.xlsx, sheet = "VariableNames", header = TRUE, check.names = FALSE)
     expect_equal(target_var_names, res_xlsx_varnames, info = "XLSX: VariableNames sheet, check.names=FALSE")
 })
 
-test_that("keep and drop arguments work correctly", {
+test_that("keep and drop arguments work correctly in XLS", {
     wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
     checkDfSubset <- data.frame(A = c(rep(NA, 3), 3:6, NA), C = c("z", "y", "x", "w", NA, "v", "u", NA), stringsAsFactors = FALSE)
-
-    # Errors for invalid keep/drop combinations
     expect_error(readWorksheet(wb.xls, "Test5", header = TRUE, keep = c("A", "C"), drop = c("B", "D")), info = "XLS: keep and drop both specified")
     expect_error(readWorksheet(wb.xls, "Test5", header = TRUE, keep = c("A", "Z")), info = "XLS: keep non-existent column name")
     expect_error(readWorksheet(wb.xls, "Test5", header = TRUE, keep = c(1, 5)), info = "XLS: keep non-existent column index") # Max 4 cols
     expect_error(readWorksheet(wb.xls, "Test5", header = TRUE, drop = c("A", "Z")), info = "XLS: drop non-existent column name")
     expect_error(readWorksheet(wb.xls, "Test5", header = TRUE, drop = c(1, 5)), info = "XLS: drop non-existent column index")
-
-    # Keep by name
     expect_equal(checkDfSubset, readWorksheet(wb.xls, "Test5", header = TRUE, keep = c("A", "C")), info = "XLS: keep by name")
-    expect_equal(checkDfSubset, readWorksheet(wb.xlsx, "Test5", header = TRUE, keep = c("A", "C")), info = "XLSX: keep by name")
     expect_error(readWorksheet(wb.xls, "Test5", header = FALSE, keep = c("A", "C")), info = "XLS: keep by name with header=FALSE")
-
-    # Drop by name
     expect_equal(checkDfSubset, readWorksheet(wb.xls, "Test5", header = TRUE, drop = c("B", "D")), info = "XLS: drop by name")
-    expect_equal(checkDfSubset, readWorksheet(wb.xlsx, "Test5", header = TRUE, drop = c("B", "D")), info = "XLSX: drop by name")
     expect_error(readWorksheet(wb.xls, "Test5", header = FALSE, drop = c("B", "D")), info = "XLS: drop by name with header=FALSE")
-
-    # Keep by index
     expect_equal(checkDfSubset, readWorksheet(wb.xls, "Test5", header = TRUE, keep = c(1, 3)), info = "XLS: keep by index")
-    expect_equal(checkDfSubset, readWorksheet(wb.xlsx, "Test5", header = TRUE, keep = c(1, 3)), info = "XLSX: keep by index")
-
-    # Drop by index
     expect_equal(checkDfSubset, readWorksheet(wb.xls, "Test5", header = TRUE, drop = c(2, 4)), info = "XLS: drop by index")
+})
+
+test_that("keep and drop arguments work correctly in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    checkDfSubset <- data.frame(A = c(rep(NA, 3), 3:6, NA), C = c("z", "y", "x", "w", NA, "v", "u", NA), stringsAsFactors = FALSE)
+    expect_equal(checkDfSubset, readWorksheet(wb.xlsx, "Test5", header = TRUE, keep = c("A", "C")), info = "XLSX: keep by name")
+    expect_equal(checkDfSubset, readWorksheet(wb.xlsx, "Test5", header = TRUE, drop = c("B", "D")), info = "XLSX: drop by name")
+    expect_equal(checkDfSubset, readWorksheet(wb.xlsx, "Test5", header = TRUE, keep = c(1, 3)), info = "XLSX: keep by index")
     expect_equal(checkDfSubset, readWorksheet(wb.xlsx, "Test5", header = TRUE, drop = c(2, 4)), info = "XLSX: drop by index")
 })
 
@@ -259,7 +286,8 @@ test_that("keep and drop arguments with specified region work correctly", {
     expect_equal(checkDfAreaSubset, do.call(readWorksheet, c(list(wb.xlsx), region_params, list(drop = 2))), info = "XLSX: Region drop by index")
 })
 
-test_that("keep/drop with multiple sheets (list argument) works", {
+test_that("keep/drop with multiple sheets works in XLS", {
+    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
     common_checkDf <- data.frame(
         NumericColumn = c(-23.63, NA, NA, 5.8, 3),
         StringColumn = c("Hello", NA, NA, NA, "World"),
@@ -277,55 +305,61 @@ test_that("keep/drop with multiple sheets (list argument) works", {
         C = c("z", "y", "x", "w", NA, "v", "u", NA), D = c(NA, 1:5, NA, NA),
         stringsAsFactors = FALSE
     )
-
-    wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
     testAAA_df <- data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE)
-
     sheets_to_read <- c("Test1", "Test4", "Test5")
-    # Keep list (same for all)
     res_xls_kl1 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, keep = c(1, 2, 3))
     expect_equal(list(Test1 = common_checkDf[1:3], Test4 = common_checkDf1[1:3], Test5 = common_checkDf2[1:3]), res_xls_kl1, info = "XLS: Multi-sheet keep same cols")
-
-    # Keep list (different for each)
-    res_xls_kl2 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, keep = list(1, 2, c(1,3))) # Test1=col1, Test4=col2, Test5=col1&3
+    res_xls_kl2 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, keep = list(1, 2, c(1,3)))
     expect_equal(list(Test1 = common_checkDf[1], Test4 = common_checkDf1[2], Test5 = common_checkDf2[c(1,3)]), res_xls_kl2, info = "XLS: Multi-sheet keep different cols (simple list)")
-
     res_xls_kl3 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, keep = list(c(1,2), c(2,3), c(1,3)))
     expect_equal(list(Test1 = common_checkDf[1:2], Test4 = common_checkDf1[2:3], Test5 = common_checkDf2[c(1,3)]), res_xls_kl3, info = "XLS: Multi-sheet keep different cols (list of vectors)")
-
-    # Keep list (shorter than num sheets, last element recycled)
-    # Recycling behavior for 'keep' list: cycles through the provided list.
     sheets_plus_aaa <- c("Test1", "Test4", "Test5", "AAA")
     res_xls_kl4 <- readWorksheet(wb.xls, sheet = sheets_plus_aaa, header = TRUE, keep = list(c(1,2), c(2,3)))
     expect_equal(list(Test1 = common_checkDf[1:2], Test4 = common_checkDf1[2:3], Test5 = common_checkDf2[1:2], AAA = testAAA_df[2:3]), res_xls_kl4, info = "XLS: Multi-sheet keep, recycle last keep spec (adjusted for observed behavior)")
-
-    # Drop list (similar logic to keep)
-    res_xls_dl1 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, drop = c(1, 2)) # Drop A,B from all
+    res_xls_dl1 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, drop = c(1, 2))
     expect_equal(list(Test1 = common_checkDf[3:4], Test4 = common_checkDf1[3:4], Test5 = common_checkDf2[3:4]), res_xls_dl1, info = "XLS: Multi-sheet drop same cols")
-
-    res_xls_dl2 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, drop = list(1, 2, c(1,3))) # Test1 drop col1, Test4 drop col2, Test5 drop col1&3
+    res_xls_dl2 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, drop = list(1, 2, c(1,3)))
     expect_equal(list(Test1 = common_checkDf[2:4], Test4 = common_checkDf1[c(1,3,4)], Test5 = common_checkDf2[c(2,4)]), res_xls_dl2, info = "XLS: Multi-sheet drop different cols (simple list)")
+})
 
-    # Corresponding XLSX tests
+test_that("keep/drop with multiple sheets works in XLSX", {
+    wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+    common_checkDf <- data.frame(
+        NumericColumn = c(-23.63, NA, NA, 5.8, 3),
+        StringColumn = c("Hello", NA, NA, NA, "World"),
+        BooleanColumn = c(TRUE, FALSE, FALSE, NA, NA),
+        DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
+        stringsAsFactors = FALSE
+    )
+    common_checkDf1 <- data.frame(
+        A = c(1:2, NA, 3:6, NA), B = letters[1:8],
+        C = c("z", "y", "x", "w", NA, "v", "u", NA), D = c(NA, 1:5, NA, NA),
+        stringsAsFactors = FALSE
+    )
+    common_checkDf2 <- data.frame(
+        A = c(rep(NA, 3), 3:6, NA), B = c(NA, letters[2:8]),
+        C = c("z", "y", "x", "w", NA, "v", "u", NA), D = c(NA, 1:5, NA, NA),
+        stringsAsFactors = FALSE
+    )
+    testAAA_df <- data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE)
+    sheets_to_read <- c("Test1", "Test4", "Test5")
     res_xlsx_kl1 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, keep = c(1, 2, 3))
     expect_equal(list(Test1 = common_checkDf[1:3], Test4 = common_checkDf1[1:3], Test5 = common_checkDf2[1:3]), res_xlsx_kl1, info = "XLSX: Multi-sheet keep same cols")
     res_xlsx_kl2 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, keep = list(1, 2, c(1,3)))
     expect_equal(list(Test1 = common_checkDf[1], Test4 = common_checkDf1[2], Test5 = common_checkDf2[c(1,3)]), res_xlsx_kl2, info = "XLSX: Multi-sheet keep different cols (simple list)")
     res_xlsx_kl3 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, keep = list(c(1,2), c(2,3), c(1,3)))
     expect_equal(list(Test1 = common_checkDf[1:2], Test4 = common_checkDf1[2:3], Test5 = common_checkDf2[c(1,3)]), res_xlsx_kl3, info = "XLSX: Multi-sheet keep different cols (list of vectors)")
+    sheets_plus_aaa <- c("Test1", "Test4", "Test5", "AAA")
     res_xlsx_kl4 <- readWorksheet(wb.xlsx, sheet = sheets_plus_aaa, header = TRUE, keep = list(c(1,2), c(2,3)))
     expect_equal(list(Test1 = common_checkDf[1:2], Test4 = common_checkDf1[2:3], Test5 = common_checkDf2[1:2], AAA = testAAA_df[2:3]), res_xlsx_kl4, info = "XLSX: Multi-sheet keep, recycle last keep spec (adjusted for observed behavior)")
-
     res_xlsx_dl1 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, drop = c(1, 2))
     expect_equal(list(Test1 = common_checkDf[3:4], Test4 = common_checkDf1[3:4], Test5 = common_checkDf2[3:4]), res_xlsx_dl1, info = "XLSX: Multi-sheet drop same cols")
     res_xlsx_dl2 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, drop = list(1, 2, c(1,3)))
     expect_equal(list(Test1 = common_checkDf[2:4], Test4 = common_checkDf1[c(1,3,4)], Test5 = common_checkDf2[c(2,4)]), res_xlsx_dl2, info = "XLSX: Multi-sheet drop different cols (simple list)")
 })
 
-test_that("autofitRow and autofitCol for BoundingBox sheet work", {
+test_that("autofitRow and autofitCol work for BoundingBox sheet in XLS", {
     wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
-
     target1_bb <- data.frame(Col1 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,7,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col2 = c(NA,NA,NA,3,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,13), Col3 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col4 = c(NA,NA,NA,4,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,9,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col5 = c(1,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col6 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col7 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,10,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col8 = c(2,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col9 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col10 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,11,NA,NA,NA,NA,NA), Col11 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col12 = c(NA,NA,NA,NA,NA,NA,5,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,12,NA,NA,NA,NA,NA), Col13 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col14 = c(NA,NA,NA,NA,NA,NA,6,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col15 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col16 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,8,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA))
     target2_orig <- data.frame( Col1 = c(9, NA, NA, NA, NA, NA), Col2 = c( NA, NA, NA, NA, NA, NA ), Col3 = c(NA, NA, NA, NA, NA, NA), Col4 = c(10, NA, NA, NA, NA, NA), Col5 = c( NA, NA, NA, NA, NA, NA ), Col6 = c(NA, NA, NA, NA, NA, NA), Col7 = c( NA, NA, NA, NA, NA, 11 ) )
     target3_orig <- data.frame(Col1=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col2=c(NA,NA,NA,9,NA,NA,NA,NA,NA,NA,NA,NA), Col3=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col4=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col5=c(NA,NA,NA,10,NA,NA,NA,NA,NA,NA,NA,NA), Col6=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col7=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col8=c(NA,NA,NA,NA,NA,NA,NA,NA,11,NA,NA,NA), Col9=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA))
@@ -333,7 +367,6 @@ test_that("autofitRow and autofitCol for BoundingBox sheet work", {
     target5_orig <- data.frame(Col1=c(NA,NA,NA,NA,4,NA), Col2=c(NA,1,NA,NA,NA,NA))
     target6_orig <- data.frame(Col1=c(NA,NA,NA,NA),Col2=c(NA,NA,NA,4),Col3=c(1,NA,NA,NA),Col4=c(NA,NA,NA,NA),Col5=c(NA,NA,NA,NA))
     target7_orig <- data.frame(Col1=c(NA,NA,NA,4),Col2=c(1,NA,NA,NA))
-
     expect_equal(target1_bb, readWorksheet(wb.xls, sheet = "BoundingBox", autofitRow = TRUE, autofitCol = TRUE, header = FALSE))
     expect_equal(target1_bb, readWorksheet(wb.xls, sheet = "BoundingBox", autofitRow = FALSE, autofitCol = FALSE, header = FALSE))
     expect_equal(target2_orig, readWorksheet(wb.xls, sheet = "BoundingBox", startRow = 20, startCol = 5, endRow = 31, endCol = 13, autofitRow = TRUE, autofitCol = TRUE, header = FALSE))
@@ -345,9 +378,8 @@ test_that("autofitRow and autofitCol for BoundingBox sheet work", {
     expect_equal(target7_orig, readWorksheet(wb.xls, sheet = "BoundingBox", startRow = 6, startCol = 5, endRow = 11, endCol = 9, autofitRow = TRUE, autofitCol = TRUE, header = FALSE))
 })
 
-test_that("autofitRow and autofitCol for BoundingBox sheet work (XLSX)", {
+test_that("autofitRow and autofitCol for BoundingBox sheet work in XLSX", {
     wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
-
     target1_bb <- data.frame(Col1 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,7,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col2 = c(NA,NA,NA,3,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,13), Col3 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col4 = c(NA,NA,NA,4,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,9,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col5 = c(1,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col6 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col7 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,10,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col8 = c(2,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col9 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col10 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,11,NA,NA,NA,NA,NA), Col11 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col12 = c(NA,NA,NA,NA,NA,NA,5,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,12,NA,NA,NA,NA,NA), Col13 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col14 = c(NA,NA,NA,NA,NA,NA,6,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col15 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col16 = c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,8,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA))
     target2_orig <- data.frame( Col1 = c(9, NA, NA, NA, NA, NA), Col2 = c( NA, NA, NA, NA, NA, NA ), Col3 = c(NA, NA, NA, NA, NA, NA), Col4 = c(10, NA, NA, NA, NA, NA), Col5 = c( NA, NA, NA, NA, NA, NA ), Col6 = c(NA, NA, NA, NA, NA, NA), Col7 = c( NA, NA, NA, NA, NA, 11 ) )
     target3_orig <- data.frame(Col1=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col2=c(NA,NA,NA,9,NA,NA,NA,NA,NA,NA,NA,NA), Col3=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col4=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col5=c(NA,NA,NA,10,NA,NA,NA,NA,NA,NA,NA,NA), Col6=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col7=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA), Col8=c(NA,NA,NA,NA,NA,NA,NA,NA,11,NA,NA,NA), Col9=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA))
@@ -355,7 +387,6 @@ test_that("autofitRow and autofitCol for BoundingBox sheet work (XLSX)", {
     target5_orig <- data.frame(Col1=c(NA,NA,NA,NA,4,NA), Col2=c(NA,1,NA,NA,NA,NA))
     target6_orig <- data.frame(Col1=c(NA,NA,NA,NA),Col2=c(NA,NA,NA,4),Col3=c(1,NA,NA,NA),Col4=c(NA,NA,NA,NA),Col5=c(NA,NA,NA,NA))
     target7_orig <- data.frame(Col1=c(NA,NA,NA,4),Col2=c(1,NA,NA,NA))
-
     expect_equal(target1_bb, readWorksheet(wb.xlsx, sheet = "BoundingBox", autofitRow = TRUE, autofitCol = TRUE, header = FALSE))
     expect_equal(target1_bb, readWorksheet(wb.xlsx, sheet = "BoundingBox", autofitRow = FALSE, autofitCol = FALSE, header = FALSE))
     expect_equal(target2_orig, readWorksheet(wb.xlsx, sheet = "BoundingBox", startRow = 20, startCol = 5, endRow = 31, endCol = 13, autofitRow = TRUE, autofitCol = TRUE, header = FALSE))
@@ -367,55 +398,50 @@ test_that("autofitRow and autofitCol for BoundingBox sheet work (XLSX)", {
     expect_equal(target7_orig, readWorksheet(wb.xlsx, sheet = "BoundingBox", startRow = 6, startCol = 5, endRow = 11, endCol = 9, autofitRow = TRUE, autofitCol = TRUE, header = FALSE))
 })
 
-test_that("useCachedValues and onErrorCell interaction works", {
+test_that("useCachedValues and onErrorCell interaction works in XLS", {
     wb.xls.cache <- loadWorkbook(test_path("resources/testCachedValues.xls"), create = FALSE)
-    wb.xlsx.cache <- loadWorkbook(test_path("resources/testCachedValues.xlsx"), create = FALSE)
-
     ref.xls.uncached <- readWorksheet(wb.xls.cache, "AllLocal", useCachedValues = FALSE)
     ref.xls.cached <- readWorksheet(wb.xls.cache, "AllLocal", useCachedValues = TRUE)
     expect_equal(ref.xls.cached, ref.xls.uncached, info = "XLS: Cached vs Uncached for AllLocal")
-
-    ref.xlsx.uncached <- readWorksheet(wb.xlsx.cache, "AllLocal", useCachedValues = FALSE)
-    ref.xlsx.cached <- readWorksheet(wb.xlsx.cache, "AllLocal", useCachedValues = TRUE)
-    expect_equal(ref.xlsx.cached, ref.xlsx.uncached, info = "XLSX: Cached vs Uncached for AllLocal")
-    expect_equal(ref.xls.uncached, ref.xlsx.uncached, info = "XLS vs XLSX Uncached for AllLocal")
-
     onErrorCell(wb.xls.cache, XLC$ERROR.STOP)
     expect_error(readWorksheet(wb.xls.cache, "HeaderRemote", useCachedValues = FALSE), info = "XLS: HeaderRemote uncached error")
     expect_error(readWorksheet(wb.xls.cache, "BodyRemote", useCachedValues = FALSE), info = "XLS: BodyRemote uncached error")
     expect_error(readWorksheet(wb.xls.cache, "AllRemote", useCachedValues = FALSE), info = "XLS: AllRemote uncached error")
+    expect_equal(readWorksheet(wb.xls.cache, "HeadersRemote", useCachedValues = TRUE), ref.xls.uncached, info = "XLS: HeadersRemote cached")
+    expect_equal(readWorksheet(wb.xls.cache, "BodyRemote", useCachedValues = TRUE), ref.xls.uncached, info = "XLS: BodyRemote cached")
+    expect_equal(readWorksheet(wb.xls.cache, "BothRemote", useCachedValues = TRUE), ref.xls.uncached, info = "XLS: BothRemote cached")
+})
 
+test_that("useCachedValues and onErrorCell interaction works in XLSX", {
+    wb.xlsx.cache <- loadWorkbook(test_path("resources/testCachedValues.xlsx"), create = FALSE)
+    ref.xlsx.uncached <- readWorksheet(wb.xlsx.cache, "AllLocal", useCachedValues = FALSE)
+    ref.xlsx.cached <- readWorksheet(wb.xlsx.cache, "AllLocal", useCachedValues = TRUE)
+    expect_equal(ref.xlsx.cached, ref.xlsx.uncached, info = "XLSX: Cached vs Uncached for AllLocal")
     onErrorCell(wb.xlsx.cache, XLC$ERROR.STOP)
     expect_error(readWorksheet(wb.xlsx.cache, "HeaderRemote", useCachedValues = FALSE), info = "XLSX: HeaderRemote uncached error")
     expect_error(readWorksheet(wb.xlsx.cache, "BodyRemote", useCachedValues = FALSE), info = "XLSX: BodyRemote uncached error")
     expect_error(readWorksheet(wb.xlsx.cache, "AllRemote", useCachedValues = FALSE), info = "XLSX: AllRemote uncached error")
-
-    # Reading with useCachedValues = TRUE should not error for remote errors if cache is good
-    expect_equal(readWorksheet(wb.xls.cache, "HeadersRemote", useCachedValues = TRUE), ref.xls.uncached, info = "XLS: HeadersRemote cached")
-    expect_equal(readWorksheet(wb.xls.cache, "BodyRemote", useCachedValues = TRUE), ref.xls.uncached, info = "XLS: BodyRemote cached")
-    expect_equal(readWorksheet(wb.xls.cache, "BothRemote", useCachedValues = TRUE), ref.xls.uncached, info = "XLS: BothRemote cached")
-
-    expect_equal(readWorksheet(wb.xlsx.cache, "HeadersRemote", useCachedValues = TRUE), ref.xlsx.uncached, info = "XLSX: HeadersRemote cached") # original test compared to ref.xls.uncached
-    expect_equal(readWorksheet(wb.xlsx.cache, "BodyRemote", useCachedValues = TRUE), ref.xlsx.uncached, info = "XLSX: BodyRemote cached")   # original test compared to ref.xls.uncached
-    expect_equal(readWorksheet(wb.xlsx.cache, "BothRemote", useCachedValues = TRUE), ref.xlsx.uncached, info = "XLSX: BothRemote cached") # original test compared to ref.xls.uncached
+    expect_equal(readWorksheet(wb.xlsx.cache, "HeadersRemote", useCachedValues = TRUE), ref.xlsx.uncached, info = "XLSX: HeadersRemote cached")
+    expect_equal(readWorksheet(wb.xlsx.cache, "BodyRemote", useCachedValues = TRUE), ref.xlsx.uncached, info = "XLSX: BodyRemote cached")
+    expect_equal(readWorksheet(wb.xlsx.cache, "BothRemote", useCachedValues = TRUE), ref.xlsx.uncached, info = "XLSX: BothRemote cached")
 })
 
-test_that("readWorksheetFromFile with specific bug cases works", {
-    # Bug 52 - useCachedValues
+test_that("readWorksheetFromFile with useCachedValues works (Bug 52)", {
     res_bug52 <- readWorksheetFromFile(test_path("resources/testBug52.xlsx"), sheet = 1, useCachedValues = TRUE)
     expected_bug52 <- data.frame(Var1 = c(2,4,6), Var2 = c("2", "nope", "6"), Var3 = c(NA,4,6), Var4 = c(2,4,6), stringsAsFactors = FALSE)
     expect_equal(res_bug52, expected_bug52, info = "Bug 52 (cached values)")
+})
 
-    # Bug 49 - rownames
+test_that("readWorksheetFromFile with rownames works (Bug 49)", {
     expected_bug49 <- data.frame(B = 1:5, row.names = letters[1:5])
     res_bug49 <- readWorksheetFromFile(test_path("resources/testBug49.xlsx"), sheet = 1, rownames = 1)
     expect_equal(res_bug49, expected_bug49, info = "Bug 49 (rownames)")
+})
 
-    # Bug 53 - dateTimeFormat and forceConversion with POSIXt
+test_that("readWorksheetFromFile with dateTimeFormat and forceConversion works (Bug 53)", {
     expected_bug53_sheet1 <- data.frame(A = c("2003-04-06", "2014-10-30", "abc"), stringsAsFactors = FALSE)
     res_bug53_sheet1 <- readWorksheetFromFile(test_path("resources/testBug53.xlsx"), sheet = 1, dateTimeFormat = "%Y-%m-%d")
     expect_equal(res_bug53_sheet1, expected_bug53_sheet1, info = "Bug 53 (sheet 1, dateTimeFormat)")
-
     expected_bug53_sheet2 <- data.frame(A = as.POSIXct(c("2015-12-01", "2015-11-17", "1984-01-11")))
     res_bug53_sheet2 <- readWorksheetFromFile(test_path("resources/testBug53.xlsx"), sheet = 2, colTypes = "POSIXt", forceConversion = TRUE)
     expect_equal(res_bug53_sheet2, expected_bug53_sheet2, info = "Bug 53 (sheet 2, colTypes POSIXt)")

--- a/tests/testthat/test.workbook.removeName.R
+++ b/tests/testthat/test.workbook.removeName.R
@@ -1,14 +1,21 @@
-test_that("test.workbook.removeName", {
-    wb.xls <- loadWorkbook("resources/testWorkbookRemoveName.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveName.xlsx",
-        create = FALSE
-    )
+test_that("removeName removes an existing name in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookRemoveName.xls", create = FALSE)
     removeName(wb.xls, "AA")
     expect_false(existsName(wb.xls, "AA"))
+})
+
+test_that("removeName removes an existing name in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveName.xlsx", create = FALSE)
     removeName(wb.xlsx, "AA")
     expect_false(existsName(wb.xlsx, "AA"))
+})
+
+test_that("removeName does not throw an error for a non-existent name in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookRemoveName.xls", create = FALSE)
     expect_error(removeName(wb.xls, "NameWhichDoesNotExist"), NA)
+})
+
+test_that("removeName does not throw an error for a non-existent name in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveName.xlsx", create = FALSE)
     expect_error(removeName(wb.xlsx, "NameWhichDoesNotExist"), NA)
 })

--- a/tests/testthat/test.workbook.removeSheet.R
+++ b/tests/testthat/test.workbook.removeSheet.R
@@ -1,16 +1,23 @@
-test_that("test.workbook.removeSheet", {
-    wb.xls <- loadWorkbook("resources/testWorkbookRemoveSheet.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveSheet.xlsx",
-        create = FALSE
-    )
+test_that("removeSheet removes an existing sheet in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookRemoveSheet.xls", create = FALSE)
     removeSheet(wb.xls, "BBB")
     expect_false(existsSheet(wb.xls, "BBB"))
+})
+
+test_that("removeSheet removes an existing sheet in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveSheet.xlsx", create = FALSE)
     removeSheet(wb.xlsx, "BBB")
     expect_false(existsSheet(wb.xlsx, "BBB"))
+})
+
+test_that("removeSheet does not throw an error for a non-existent sheet in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookRemoveSheet.xls", create = FALSE)
     expect_error(removeSheet(wb.xls, 35), NA)
     expect_error(removeSheet(wb.xls, "SheetWhichDoesNotExist"), NA)
+})
+
+test_that("removeSheet does not throw an error for a non-existent sheet in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveSheet.xlsx", create = FALSE)
     expect_error(removeSheet(wb.xlsx, 35), NA)
     expect_error(removeSheet(wb.xlsx, "SheetWhichDoesNotExist"), NA)
 })

--- a/tests/testthat/test.workbook.saveWorkbook.R
+++ b/tests/testthat/test.workbook.saveWorkbook.R
@@ -1,34 +1,49 @@
-test_that("test.workbook.saveWorkbook - always run", {
-    # Add tests here that should always run, if any.
-    # For now, this block will be empty as all existing tests are conditional.
-    expect_true(TRUE) # Placeholder to ensure the test block is not empty
+test_that("saveWorkbook saves an XLS file", {
+    skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+    file.xls <- "testWorkbookSaveWorkbook.xls"
+    on.exit(if (file.exists(file.xls)) file.remove(file.xls))
+
+    wb.xls <- loadWorkbook(file.xls, create = TRUE)
+    expect_false(file.exists(file.xls))
+    saveWorkbook(wb.xls)
+    expect_true(file.exists(file.xls))
 })
 
-test_that("test.workbook.saveWorkbook - full test suite only", {
+test_that("saveWorkbook saves an XLSX file", {
     skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-
-    file.xls <- "testWorkbookSaveWorkbook.xls"
     file.xlsx <- "testWorkbookSaveWorkbook.xlsx"
-    file.remove(file.xls)
-    file.remove(file.xlsx)
-    wb.xls <- loadWorkbook(file.xls, create = TRUE)
+    on.exit(if (file.exists(file.xlsx)) file.remove(file.xlsx))
+
     wb.xlsx <- loadWorkbook(file.xlsx, create = TRUE)
-    expect_false(file.exists(file.xls))
     expect_false(file.exists(file.xlsx))
-    saveWorkbook(wb.xls)
     saveWorkbook(wb.xlsx)
-    expect_true(file.exists(file.xls))
     expect_true(file.exists(file.xlsx))
+})
+
+test_that("saveWorkbook saves an XLS file to a new location", {
+    skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+    file.xls <- "testWorkbookSaveWorkbook.xls"
     newFile.xls <- "saveAsWorkbook.xls"
-    if (file.exists(newFile.xls)) {
-        file.remove(newFile.xls)
-    }
+    on.exit({
+        if (file.exists(file.xls)) file.remove(file.xls)
+        if (file.exists(newFile.xls)) file.remove(newFile.xls)
+    })
+
+    wb.xls <- loadWorkbook(file.xls, create = TRUE)
     saveWorkbook(wb.xls, file = newFile.xls)
     expect_true(file.exists(newFile.xls))
+})
+
+test_that("saveWorkbook saves an XLSX file to a new location", {
+    skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+    file.xlsx <- "testWorkbookSaveWorkbook.xlsx"
     newFile.xlsx <- "saveAsWorkbook.xlsx"
-    if (file.exists(newFile.xlsx)) {
-        file.remove(newFile.xlsx)
-    }
+    on.exit({
+        if (file.exists(file.xlsx)) file.remove(file.xlsx)
+        if (file.exists(newFile.xlsx)) file.remove(newFile.xlsx)
+    })
+
+    wb.xlsx <- loadWorkbook(file.xlsx, create = TRUE)
     saveWorkbook(wb.xlsx, file = newFile.xlsx)
     expect_true(file.exists(newFile.xlsx))
 })

--- a/tests/testthat/test.workbook.setMissingValue.R
+++ b/tests/testthat/test.workbook.setMissingValue.R
@@ -28,9 +28,11 @@ test_that("setMissingValue works correctly for a single value in XLSX", {
 
     writeNamedRegion(wb.xlsx, data, name = name)
     res <- readNamedRegion(wb.xlsx, name = name)
+    attr(data, "worksheetScope") <- ""
     expect_equal(res, data)
 
     expect <- data.frame(A = c("4.2", "-3.2", "missing", "1.34"), B = c("A", "missing", "C", "D"), stringsAsFactors = FALSE)
+    attr(expect, "worksheetScope") <- ""
     setMissingValue(wb.xlsx, value = "missing")
     writeNamedRegion(wb.xlsx, data, name = name)
     setMissingValue(wb.xlsx, value = NULL)
@@ -46,6 +48,7 @@ test_that("setMissingValue works with a vector of values in XLS", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xls, value = c("NA", "missing", "empty"))
     res <- readNamedRegion(wb.xls, name = "Missing1")
+    attr(expect, "worksheetScope") <- ""
     expect_equal(expect, res)
 })
 
@@ -57,6 +60,7 @@ test_that("setMissingValue works with a vector of values in XLSX", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xlsx, value = c("NA", "missing", "empty"))
     res <- readNamedRegion(wb.xlsx, name = "Missing1")
+    attr(expect, "worksheetScope") <- ""
     expect_equal(expect, res)
 })
 
@@ -68,6 +72,7 @@ test_that("setMissingValue works with a list of values in XLS", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xls, value = list("NA", "missing", "empty", -9999))
     res <- readNamedRegion(wb.xls, name = "Missing2")
+    attr(expect, "worksheetScope") <- ""
     expect_equal(expect, res)
 })
 
@@ -79,5 +84,6 @@ test_that("setMissingValue works with a list of values in XLSX", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xlsx, value = list("NA", "missing", "empty", -9999))
     res <- readNamedRegion(wb.xlsx, name = "Missing2")
+    attr(expect, "worksheetScope") <- ""
     expect_equal(expect, res)
 })

--- a/tests/testthat/test.workbook.setMissingValue.R
+++ b/tests/testthat/test.workbook.setMissingValue.R
@@ -1,102 +1,81 @@
-test_that("test.workbook.setMissingValue", {
-    wb.xls <- loadWorkbook("resources/testWorkbookSetMissingValue.xls",
-        create = TRUE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookSetMissingValue.xlsx",
-        create = TRUE
-    )
-    data <- data.frame(A = c(4.2, -3.2, NA, 1.34), B = c(
-        "A",
-        NA, "C", "D"
-    ), stringsAsFactors = FALSE)
-    attr(data, "worksheetScope") <- ""
+test_that("setMissingValue works correctly for a single value in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookSetMissingValue.xls", create = TRUE)
+    data <- data.frame(A = c(4.2, -3.2, NA, 1.34), B = c("A", NA, "C", "D"), stringsAsFactors = FALSE)
     name <- "missing"
     createSheet(wb.xls, name = name)
-    createName(wb.xls, name = name, formula = paste(name, "$A$1",
-        sep = "!"
-    ))
-    createSheet(wb.xlsx, name = name)
-    createName(wb.xlsx, name = name, formula = paste(name, "$A$1",
-        sep = "!"
-    ))
+    createName(wb.xls, name = name, formula = paste(name, "$A$1", sep = "!"))
+
     writeNamedRegion(wb.xls, data, name = name)
     res <- readNamedRegion(wb.xls, name = name)
-    expect_equal(res, data)
-    writeNamedRegion(wb.xlsx, data, name = name)
-    res <- readNamedRegion(wb.xlsx, name = name)
-    expect_equal(res, data)
-    expect <- data.frame(
-        A = c("4.2", "-3.2", "missing", "1.34"),
-        B = c("A", "missing", "C", "D"), stringsAsFactors = FALSE
-    )
-    attr(expect, "worksheetScope") <- ""
+    expect_equal(res, data, ignore_attr = TRUE)
+
+    expect <- data.frame(A = c("4.2", "-3.2", "missing", "1.34"), B = c("A", "missing", "C", "D"), stringsAsFactors = FALSE)
     setMissingValue(wb.xls, value = "missing")
     writeNamedRegion(wb.xls, data, name = name)
     setMissingValue(wb.xls, value = NULL)
     res <- readNamedRegion(wb.xls, name = name)
-    expect_equal(res, expect)
-    expect <- data.frame(
-        A = c("4.2", "-3.2", "missing", "1.34"),
-        B = c("A", "missing", "C", "D"), stringsAsFactors = FALSE
-    )
-    attr(expect, "worksheetScope") <- ""
+    expect_equal(res, expect, ignore_attr = TRUE)
+})
+
+test_that("setMissingValue works correctly for a single value in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookSetMissingValue.xlsx", create = TRUE)
+    data <- data.frame(A = c(4.2, -3.2, NA, 1.34), B = c("A", NA, "C", "D"), stringsAsFactors = FALSE)
+    name <- "missing"
+    createSheet(wb.xlsx, name = name)
+    createName(wb.xlsx, name = name, formula = paste(name, "$A$1", sep = "!"))
+
+    writeNamedRegion(wb.xlsx, data, name = name)
+    res <- readNamedRegion(wb.xlsx, name = name)
+    expect_equal(res, data, ignore_attr = TRUE)
+
+    expect <- data.frame(A = c("4.2", "-3.2", "missing", "1.34"), B = c("A", "missing", "C", "D"), stringsAsFactors = FALSE)
     setMissingValue(wb.xlsx, value = "missing")
     writeNamedRegion(wb.xlsx, data, name = name)
     setMissingValue(wb.xlsx, value = NULL)
     res <- readNamedRegion(wb.xlsx, name = name)
-    expect_equal(res, expect)
-    setMissingValue(wb.xls, value = "missing")
-    writeNamedRegion(wb.xls, data, name = name)
-    res <- readNamedRegion(wb.xls, name = name)
-    expect_equal(res, data)
-    setMissingValue(wb.xlsx, value = "missing")
-    writeNamedRegion(wb.xlsx, data, name = name)
-    res <- readNamedRegion(wb.xlsx, name = name)
-    expect_equal(res, data)
-    wb.xls <- loadWorkbook("resources/testWorkbookMissingValue.xls",
-        create = FALSE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookMissingValue.xlsx",
-        create = FALSE
-    )
-    expect <- data.frame(A = c(NA, -3.2, 3.4, NA, 8, NA), B = c(
-        "a",
-        NA, "c", "x", "a", "o"
-    ), C = c(
-        TRUE, TRUE, FALSE, NA,
-        FALSE, NA
-    ), D = as.POSIXct(c(
-        "1981-12-01 00:00:00", "1981-12-02 00:00:00",
-        NA, NA, NA, "1981-12-06 00:00:00"
-    )), stringsAsFactors = FALSE)
-    attr(expect, "worksheetScope") <- ""
+    expect_equal(res, expect, ignore_attr = TRUE)
+})
+
+test_that("setMissingValue works with a vector of values in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookMissingValue.xls", create = FALSE)
+    expect <- data.frame(A = c(NA, -3.2, 3.4, NA, 8, NA), B = c("a", NA, "c", "x", "a", "o"),
+                         C = c(TRUE, TRUE, FALSE, NA, FALSE, NA),
+                         D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
+                         stringsAsFactors = FALSE)
     setMissingValue(wb.xls, value = c("NA", "missing", "empty"))
     res <- readNamedRegion(wb.xls, name = "Missing1")
-    expect_equal(expect, res)
+    expect_equal(expect, res, ignore_attr = TRUE)
+})
+
+test_that("setMissingValue works with a vector of values in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookMissingValue.xlsx", create = FALSE)
+    expect <- data.frame(A = c(NA, -3.2, 3.4, NA, 8, NA), B = c("a", NA, "c", "x", "a", "o"),
+                         C = c(TRUE, TRUE, FALSE, NA, FALSE, NA),
+                         D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
+                         stringsAsFactors = FALSE)
     setMissingValue(wb.xlsx, value = c("NA", "missing", "empty"))
     res <- readNamedRegion(wb.xlsx, name = "Missing1")
-    expect_equal(expect, res)
-    expect <- data.frame(A = c(NA, -3.2, NA, NA, 8, NA), B = c(
-        "a",
-        NA, "c", "x", "a", "o"
-    ), C = c(
-        TRUE, NA, FALSE, NA, FALSE,
-        NA
-    ), D = as.POSIXct(c(
-        "1981-12-01 00:00:00", "1981-12-02 00:00:00",
-        NA, NA, NA, "1981-12-06 00:00:00"
-    )), stringsAsFactors = FALSE)
-    attr(expect, "worksheetScope") <- ""
-    setMissingValue(wb.xls, value = list(
-        "NA", "missing", "empty",
-        -9999
-    ))
+    expect_equal(expect, res, ignore_attr = TRUE)
+})
+
+test_that("setMissingValue works with a list of values in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookMissingValue.xls", create = FALSE)
+    expect <- data.frame(A = c(NA, -3.2, NA, NA, 8, NA), B = c("a", NA, "c", "x", "a", "o"),
+                         C = c(TRUE, NA, FALSE, NA, FALSE, NA),
+                         D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
+                         stringsAsFactors = FALSE)
+    setMissingValue(wb.xls, value = list("NA", "missing", "empty", -9999))
     res <- readNamedRegion(wb.xls, name = "Missing2")
-    expect_equal(expect, res)
-    setMissingValue(wb.xlsx, value = list(
-        "NA", "missing", "empty",
-        -9999
-    ))
+    expect_equal(expect, res, ignore_attr = TRUE)
+})
+
+test_that("setMissingValue works with a list of values in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookMissingValue.xlsx", create = FALSE)
+    expect <- data.frame(A = c(NA, -3.2, NA, NA, 8, NA), B = c("a", NA, "c", "x", "a", "o"),
+                         C = c(TRUE, NA, FALSE, NA, FALSE, NA),
+                         D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
+                         stringsAsFactors = FALSE)
+    setMissingValue(wb.xlsx, value = list("NA", "missing", "empty", -9999))
     res <- readNamedRegion(wb.xlsx, name = "Missing2")
-    expect_equal(expect, res)
+    expect_equal(expect, res, ignore_attr = TRUE)
 })

--- a/tests/testthat/test.workbook.setMissingValue.R
+++ b/tests/testthat/test.workbook.setMissingValue.R
@@ -7,14 +7,16 @@ test_that("setMissingValue works correctly for a single value in XLS", {
 
     writeNamedRegion(wb.xls, data, name = name)
     res <- readNamedRegion(wb.xls, name = name)
-    expect_equal(res, data, ignore_attr = TRUE)
+    attr(data, "worksheetScope") <- ""
+    expect_equal(res, data)
 
     expect <- data.frame(A = c("4.2", "-3.2", "missing", "1.34"), B = c("A", "missing", "C", "D"), stringsAsFactors = FALSE)
+    attr(expect, "worksheetScope") <- ""
     setMissingValue(wb.xls, value = "missing")
     writeNamedRegion(wb.xls, data, name = name)
     setMissingValue(wb.xls, value = NULL)
     res <- readNamedRegion(wb.xls, name = name)
-    expect_equal(res, expect, ignore_attr = TRUE)
+    expect_equal(res, expect)
 })
 
 test_that("setMissingValue works correctly for a single value in XLSX", {
@@ -26,14 +28,14 @@ test_that("setMissingValue works correctly for a single value in XLSX", {
 
     writeNamedRegion(wb.xlsx, data, name = name)
     res <- readNamedRegion(wb.xlsx, name = name)
-    expect_equal(res, data, ignore_attr = TRUE)
+    expect_equal(res, data)
 
     expect <- data.frame(A = c("4.2", "-3.2", "missing", "1.34"), B = c("A", "missing", "C", "D"), stringsAsFactors = FALSE)
     setMissingValue(wb.xlsx, value = "missing")
     writeNamedRegion(wb.xlsx, data, name = name)
     setMissingValue(wb.xlsx, value = NULL)
     res <- readNamedRegion(wb.xlsx, name = name)
-    expect_equal(res, expect, ignore_attr = TRUE)
+    expect_equal(res, expect)
 })
 
 test_that("setMissingValue works with a vector of values in XLS", {
@@ -44,7 +46,7 @@ test_that("setMissingValue works with a vector of values in XLS", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xls, value = c("NA", "missing", "empty"))
     res <- readNamedRegion(wb.xls, name = "Missing1")
-    expect_equal(expect, res, ignore_attr = TRUE)
+    expect_equal(expect, res)
 })
 
 test_that("setMissingValue works with a vector of values in XLSX", {
@@ -55,7 +57,7 @@ test_that("setMissingValue works with a vector of values in XLSX", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xlsx, value = c("NA", "missing", "empty"))
     res <- readNamedRegion(wb.xlsx, name = "Missing1")
-    expect_equal(expect, res, ignore_attr = TRUE)
+    expect_equal(expect, res)
 })
 
 test_that("setMissingValue works with a list of values in XLS", {
@@ -66,7 +68,7 @@ test_that("setMissingValue works with a list of values in XLS", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xls, value = list("NA", "missing", "empty", -9999))
     res <- readNamedRegion(wb.xls, name = "Missing2")
-    expect_equal(expect, res, ignore_attr = TRUE)
+    expect_equal(expect, res)
 })
 
 test_that("setMissingValue works with a list of values in XLSX", {
@@ -77,5 +79,5 @@ test_that("setMissingValue works with a list of values in XLSX", {
                          stringsAsFactors = FALSE)
     setMissingValue(wb.xlsx, value = list("NA", "missing", "empty", -9999))
     res <- readNamedRegion(wb.xlsx, name = "Missing2")
-    expect_equal(expect, res, ignore_attr = TRUE)
+    expect_equal(expect, res)
 })

--- a/tests/testthat/test.workbook.writeNamedRegion.R
+++ b/tests/testthat/test.workbook.writeNamedRegion.R
@@ -1,55 +1,87 @@
-test_that("test.workbook.writeNamedRegion", {
-    wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls",
-        create = TRUE
-    )
-    wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx",
-        create = TRUE
-    )
+test_that("writeNamedRegion throws error for non-data.frame objects in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
     createName(wb.xls, "test1", "Test1!$C$8")
     expect_error(writeNamedRegion(wb.xls, search, "test1"), "cannot coerce class")
+})
+
+test_that("writeNamedRegion throws error for non-data.frame objects in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
     createName(wb.xlsx, "test1", "Test1!$C$8")
     expect_error(writeNamedRegion(wb.xlsx, search, "test1"), "cannot coerce class")
+})
+
+test_that("writeNamedRegion throws error for non-existent names in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
     expect_error(writeNamedRegion(wb.xls, mtcars, "nameDoesNotExist"), "IllegalArgumentException")
+})
+
+test_that("writeNamedRegion throws error for non-existent names in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
     expect_error(writeNamedRegion(wb.xlsx, mtcars, "nameDoesNotExist"), "IllegalArgumentException")
+})
+
+test_that("writeNamedRegion throws error for non-existent sheets in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
     createName(wb.xls, "nope", "NonExistingSheet!A1")
     expect_error(writeNamedRegion(wb.xls, mtcars, "nope"), "IllegalArgumentException")
+})
+
+test_that("writeNamedRegion throws error for non-existent sheets in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
     createName(wb.xlsx, "nope", "NonExistingSheet!A1")
     expect_error(writeNamedRegion(wb.xlsx, mtcars, "nope"), "IllegalArgumentException")
+})
+
+test_that("writeNamedRegion handles empty data frames in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
     createSheet(wb.xls, "empty")
     createName(wb.xls, "empty1", "empty!A1")
     createName(wb.xls, "empty2", "empty!D10")
-    # Writing empty data frames is allowed
     writeNamedRegion(wb.xls, data.frame(), "empty1")
-    writeNamedRegion(wb.xls, data.frame(
-        a = character(0),
-        b = numeric(0)
-    ), "empty2")
+    writeNamedRegion(wb.xls, data.frame(a = character(0), b = numeric(0)), "empty2")
+    # No assertion, just checking that it runs without error
+    expect_true(TRUE)
+})
+
+test_that("writeNamedRegion handles empty data frames in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
     createSheet(wb.xlsx, "empty")
     createName(wb.xlsx, "empty1", "empty!A1")
     createName(wb.xlsx, "empty2", "empty!D10")
-    # Writing empty data frames is allowed
-    writeNamedRegion(
-        wb.xlsx, data.frame(),
-        "empty1"
-    )
-    writeNamedRegion(wb.xlsx, data.frame(
-        a = character(0),
-        b = numeric(0)
-    ), "empty2")
+    writeNamedRegion(wb.xlsx, data.frame(), "empty1")
+    writeNamedRegion(wb.xlsx, data.frame(a = character(0), b = numeric(0)), "empty2")
+    # No assertion, just checking that it runs without error
+    expect_true(TRUE)
+})
+
+test_that("writeNamedRegion with overwriteFormulaCells = FALSE works in XLS", {
     wb.xls <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xls")
+    mtcars_mod <- mtcars
+    mtcars_mod$carb <- mtcars_mod$gear
+    writeNamedRegion(wb.xls, mtcars, "mtcars_formula", overwriteFormulaCells = FALSE)
+    res <- readNamedRegion(wb.xls, "mtcars_formula")
+    expect_equal(res, normalizeDataframe(mtcars_mod), ignore_attr = TRUE)
+})
+
+test_that("writeNamedRegion with overwriteFormulaCells = FALSE works in XLSX", {
     wb.xlsx <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xlsx")
     mtcars_mod <- mtcars
     mtcars_mod$carb <- mtcars_mod$gear
-    test_overwrite_formula <- function(wb, expected, overwrite = TRUE) {
-        writeNamedRegion(wb, mtcars, "mtcars_formula", overwriteFormulaCells = overwrite)
-        res <- readNamedRegion(wb, "mtcars_formula")
-        expect_equal(res, normalizeDataframe(expected),
-            check.attributes = FALSE,
-            check.names = TRUE
-        )
-    }
-    test_overwrite_formula(wb.xls, mtcars_mod, overwrite = FALSE)
-    test_overwrite_formula(wb.xlsx, mtcars_mod, overwrite = FALSE)
-    test_overwrite_formula(wb.xls, mtcars)
-    test_overwrite_formula(wb.xlsx, mtcars)
+    writeNamedRegion(wb.xlsx, mtcars, "mtcars_formula", overwriteFormulaCells = FALSE)
+    res <- readNamedRegion(wb.xlsx, "mtcars_formula")
+    expect_equal(res, normalizeDataframe(mtcars_mod), ignore_attr = TRUE)
+})
+
+test_that("writeNamedRegion with overwriteFormulaCells = TRUE works in XLS", {
+    wb.xls <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xls")
+    writeNamedRegion(wb.xls, mtcars, "mtcars_formula", overwriteFormulaCells = TRUE)
+    res <- readNamedRegion(wb.xls, "mtcars_formula")
+    expect_equal(res, normalizeDataframe(mtcars), ignore_attr = TRUE)
+})
+
+test_that("writeNamedRegion with overwriteFormulaCells = TRUE works in XLSX", {
+    wb.xlsx <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xlsx")
+    writeNamedRegion(wb.xlsx, mtcars, "mtcars_formula", overwriteFormulaCells = TRUE)
+    res <- readNamedRegion(wb.xlsx, "mtcars_formula")
+    expect_equal(res, normalizeDataframe(mtcars), ignore_attr = TRUE)
 })

--- a/tests/testthat/test.workbook.writeWorksheet.R
+++ b/tests/testthat/test.workbook.writeWorksheet.R
@@ -22,7 +22,7 @@ test_that("test.workbook.writeWorksheet", {
         )
         res <- readWorksheet(wb, "mtcars_formula")
         expect_equal(res, normalizeDataframe(expected),
-            check.attributes = FALSE,
+            ignore_attr = TRUE,
             check.names = TRUE
         )
     }

--- a/tests/testthat/test.workbook.writeWorksheet.R
+++ b/tests/testthat/test.workbook.writeWorksheet.R
@@ -22,8 +22,7 @@ test_that("test.workbook.writeWorksheet", {
         )
         res <- readWorksheet(wb, "mtcars_formula")
         expect_equal(res, normalizeDataframe(expected),
-            ignore_attr = TRUE,
-            check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     test_overwrite_formula(wb.xls, mtcars_mod, overwrite = FALSE)

--- a/tests/testthat/test.writeAndReadNamedRegion.R
+++ b/tests/testthat/test.writeAndReadNamedRegion.R
@@ -19,7 +19,7 @@ test_that("test.writeAndReadNamedRegion - always run", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = namedRegion)
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            check.attributes = FALSE, check.names = TRUE
+            ignore_attr = TRUE, check.names = TRUE
         )
     }
     cdf <- data.frame(
@@ -76,7 +76,7 @@ test_that("test.writeAndReadNamedRegion - always run", {
         rownames = "Car"
     )
     res <- readNamedRegion(wb.xls, "rownames")
-    expect_equal(res, XLConnect:::includeRownames(mtcars, "Car"), check.attributes = FALSE)
+    expect_equal(res, XLConnect:::includeRownames(mtcars, "Car"), ignore_attr = TRUE)
     createSheet(wb.xlsx, name = "rownames")
     createName(wb.xlsx, name = "rownames", formula = "rownames!$F$16")
     writeNamedRegion(wb.xlsx, mtcars,
@@ -84,7 +84,7 @@ test_that("test.writeAndReadNamedRegion - always run", {
         rownames = "Car"
     )
     res <- readNamedRegion(wb.xlsx, "rownames")
-    expect_equal(res, XLConnect:::includeRownames(mtcars, "Car"), check.attributes = FALSE)
+    expect_equal(res, XLConnect:::includeRownames(mtcars, "Car"), ignore_attr = TRUE)
     createSheet(wb.xls, name = "rownames2")
     createName(wb.xls, name = "rownames2", formula = "rownames2!$K$5")
     writeNamedRegion(wb.xls, mtcars,
@@ -128,7 +128,7 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = namedRegion)
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            check.attributes = FALSE, check.names = TRUE
+            ignore_attr = TRUE, check.names = TRUE
         )
     }
     testDataFrameNameScope <- function(wb, df, lref) {
@@ -147,7 +147,7 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = worksheetScopeName)
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            check.attributes = FALSE, check.names = TRUE
+            ignore_attr = TRUE, check.names = TRUE
         )
     }
     testDataFrameGlobalExplicit <- function(wb, df, lref) {
@@ -166,7 +166,7 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = "")
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            check.attributes = FALSE, check.names = TRUE
+            ignore_attr = TRUE, check.names = TRUE
         )
     }
     testDataFrameGlobalAndScoped <- function(wb, df_global, df_scoped,
@@ -194,13 +194,13 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
             normalizeDataframe(df_scoped, replaceInf = TRUE)
         )
         expect_equal(dfs_norm, res_full,
-            check.attributes = FALSE,
+            ignore_attr = TRUE,
             check.names = TRUE
         )
         res_global_prio <- readNamedRegion(wb, namedRegion)
         expect_equal(normalizeDataframe(df_global, replaceInf = TRUE),
             res_global_prio,
-            check.attributes = FALSE, check.names = TRUE
+            ignore_attr = TRUE, check.names = TRUE
         )
     }
     testDataFrame(wb.xls, mtcars, "$C$8")

--- a/tests/testthat/test.writeAndReadNamedRegion.R
+++ b/tests/testthat/test.writeAndReadNamedRegion.R
@@ -19,7 +19,7 @@ test_that("test.writeAndReadNamedRegion - always run", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = namedRegion)
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            ignore_attr = TRUE, check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     cdf <- data.frame(
@@ -128,7 +128,7 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = namedRegion)
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            ignore_attr = TRUE, check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     testDataFrameNameScope <- function(wb, df, lref) {
@@ -147,7 +147,7 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = worksheetScopeName)
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            ignore_attr = TRUE, check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     testDataFrameGlobalExplicit <- function(wb, df, lref) {
@@ -166,7 +166,7 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = "")
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            ignore_attr = TRUE, check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     testDataFrameGlobalAndScoped <- function(wb, df_global, df_scoped,
@@ -194,13 +194,12 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
             normalizeDataframe(df_scoped, replaceInf = TRUE)
         )
         expect_equal(dfs_norm, res_full,
-            ignore_attr = TRUE,
-            check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names", "names")
         )
         res_global_prio <- readNamedRegion(wb, namedRegion)
         expect_equal(normalizeDataframe(df_global, replaceInf = TRUE),
             res_global_prio,
-            ignore_attr = TRUE, check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     testDataFrame(wb.xls, mtcars, "$C$8")

--- a/tests/testthat/test.writeAndReadNamedRegion.R
+++ b/tests/testthat/test.writeAndReadNamedRegion.R
@@ -19,7 +19,7 @@ test_that("test.writeAndReadNamedRegion - always run", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = namedRegion)
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            ignore_attr = c("worksheetScope", "row.names")
+            ignore_attr = c("worksheetScope")
         )
     }
     cdf <- data.frame(
@@ -166,7 +166,7 @@ test_that("test.writeAndReadNamedRegion - full test suite only", {
         res <- readNamedRegion(wb, namedRegion, worksheetScope = "")
         expect_equal(normalizeDataframe(df, replaceInf = TRUE),
             res,
-            ignore_attr = c("worksheetScope", "row.names")
+            ignore_attr = c("worksheetScope")
         )
     }
     testDataFrameGlobalAndScoped <- function(wb, df_global, df_scoped,

--- a/tests/testthat/test.writeAndReadWorksheet.R
+++ b/tests/testthat/test.writeAndReadWorksheet.R
@@ -17,7 +17,7 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
             startCol = startCol, endRow = 0, endCol = 0
         )
         expect_equal(normalizeDataframe(df), res,
-            check.attributes = FALSE,
+            ignore_attr = TRUE,
             check.names = TRUE
         )
     }
@@ -119,7 +119,7 @@ test_that("test.workbook.writeAndReadWorksheet - full test suite only", {
             startCol = startCol, endRow = 0, endCol = 0
         )
         expect_equal(normalizeDataframe(df), res,
-            check.attributes = FALSE,
+            ignore_attr = TRUE,
             check.names = TRUE
         )
     }

--- a/tests/testthat/test.writeAndReadWorksheet.R
+++ b/tests/testthat/test.writeAndReadWorksheet.R
@@ -16,9 +16,7 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
             startRow = startRow,
             startCol = startCol, endRow = 0, endCol = 0
         )
-        expect_equal(normalizeDataframe(df), res,
-            ignore_attr = c("worksheetScope", "row.names")
-        )
+        expect_equal( normalizeDataframe(df), res, ignore_attr = c("worksheetScope"))
     }
     cdf <- data.frame(
         Column.A = c(

--- a/tests/testthat/test.writeAndReadWorksheet.R
+++ b/tests/testthat/test.writeAndReadWorksheet.R
@@ -17,8 +17,7 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
             startCol = startCol, endRow = 0, endCol = 0
         )
         expect_equal(normalizeDataframe(df), res,
-            ignore_attr = TRUE,
-            check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     cdf <- data.frame(
@@ -119,8 +118,7 @@ test_that("test.workbook.writeAndReadWorksheet - full test suite only", {
             startCol = startCol, endRow = 0, endCol = 0
         )
         expect_equal(normalizeDataframe(df), res,
-            ignore_attr = TRUE,
-            check.names = TRUE
+            ignore_attr = c("worksheetScope", "row.names")
         )
     }
     testDataFrame(wb.xls, mtcars, 8, 13)

--- a/tests/testthat/test.writeNamedRegionToFile.R
+++ b/tests/testthat/test.writeNamedRegionToFile.R
@@ -23,8 +23,7 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
         writeNamedRegionToFile(file, df, name, formula = paste(worksheet,
             "A1", sep = "!"))
         res <- readNamedRegionFromFile(file, name)
-        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE,
-            check.names = TRUE)
+        expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope", "row.names"))
     }
     testDataFrame(file.xls, mtcars)
     testDataFrame(file.xlsx, mtcars)

--- a/tests/testthat/test.writeNamedRegionToFile.R
+++ b/tests/testthat/test.writeNamedRegionToFile.R
@@ -23,7 +23,7 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
         writeNamedRegionToFile(file, df, name, formula = paste(worksheet,
             "A1", sep = "!"))
         res <- readNamedRegionFromFile(file, name)
-        expect_equal(normalizeDataframe(df), res, check.attributes = FALSE,
+        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE,
             check.names = TRUE)
     }
     testDataFrame(file.xls, mtcars)

--- a/tests/testthat/test.writeWorksheetToFile.R
+++ b/tests/testthat/test.writeWorksheetToFile.R
@@ -9,7 +9,7 @@ testDataFrame <- function(file, df) {
     expect_equal(
         normalizeDataframe(df),
         res,
-        check.attributes = FALSE,
+        ignore_attr = TRUE,
     )
 }
 

--- a/tests/testthat/test.writeWorksheetToFile.R
+++ b/tests/testthat/test.writeWorksheetToFile.R
@@ -1,82 +1,69 @@
-test_that("test.writeWorksheetToFile - always run", {
-    # Add tests here that should always run, if any.
-    # For now, this block will be empty as all existing tests are conditional.
-    expect_true(TRUE) # Placeholder to ensure the test block is not empty
+test_that("writeWorksheetToFile writes and reads a data frame to/from an XLS file", {
+    skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+    file.xls <- "testWriteWorksheetToFileWorkbook.xls"
+    on.exit(if (file.exists(file.xls)) file.remove(file.xls))
+
+    testDataFrame <- function(df) {
+        worksheet <- deparse(substitute(df))
+        name <- paste(worksheet, "Region", sep = "")
+        writeWorksheetToFile(file.xls, data = df, sheet = name)
+        res <- readWorksheetFromFile(file.xls, sheet = name)
+        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE)
+    }
+
+    testDataFrame(mtcars)
+    testDataFrame(airquality)
 })
 
-test_that("test.writeWorksheetToFile - full test suite only", {
+test_that("writeWorksheetToFile writes and reads a data frame to/from an XLSX file", {
     skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-
-    file.xls <- "testWriteWorksheetToFileWorkbook.xls"
     file.xlsx <- "testWriteWorksheetToFileWorkbook.xlsx"
-    if (file.exists(file.xls)) {
-        file.remove(file.xls)
-    }
-    if (file.exists(file.xlsx)) {
-        file.remove(file.xlsx)
-    }
-    testDataFrame <- function(file, df) {
+    on.exit(if (file.exists(file.xlsx)) file.remove(file.xlsx))
+
+    testDataFrame <- function(df) {
         worksheet <- deparse(substitute(df))
-        print(paste("Writing dataset ", worksheet, "to file",
-            file))
         name <- paste(worksheet, "Region", sep = "")
-        writeWorksheetToFile(file, data = df, sheet = name)
-        res <- readWorksheetFromFile(file, sheet = name)
-        expect_equal(normalizeDataframe(df), res, check.attributes = FALSE,
-            check.names = TRUE)
+        writeWorksheetToFile(file.xlsx, data = df, sheet = name)
+        res <- readWorksheetFromFile(file.xlsx, sheet = name)
+        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE)
     }
-    testDataFrame(file.xls, mtcars)
-    testDataFrame(file.xlsx, mtcars)
-    testDataFrame(file.xls, airquality)
-    testDataFrame(file.xlsx, airquality)
-    testDataFrame(file.xls, attenu)
-    testDataFrame(file.xlsx, attenu)
-    testDataFrame(file.xls, ChickWeight)
-    testDataFrame(file.xlsx, ChickWeight)
-    CO = CO2
-    testDataFrame(file.xls, CO2)
-    testDataFrame(file.xlsx, CO2)
-    testDataFrame(file.xls, iris)
-    testDataFrame(file.xlsx, iris)
-    testDataFrame(file.xls, longley)
-    testDataFrame(file.xlsx, longley)
-    testDataFrame(file.xls, morley)
-    testDataFrame(file.xlsx, morley)
-    testDataFrame(file.xls, swiss)
-    testDataFrame(file.xlsx, swiss)
-    cdf <- data.frame(Column.A = c(1, 2, 3, NA, 5, 6, 7,
-        8, NA, 10), Column.B = c(-4, -3, NA, -1, 0, NA, NA,
-        3, 4, 5), Column.C = c("Anna", "???", NA, "", NA,
-        "$!?&%", "(?2@?~?'^*#|)", "{}[]:,;-_<>", "\\sadf\n\nv",
-        "a b c"), Column.D = c(pi, -pi, NA, sqrt(2), sqrt(0.3),
-        -sqrt(pi), exp(1), log(2), sin(2), -tan(2)), Column.E = c(TRUE,
-        TRUE, NA, NA, FALSE, FALSE, TRUE, NA, FALSE, TRUE),
-        Column.F = c("High", "Medium", "Low", "Low", "Low",
-            NA, NA, "Medium", "High", "High"), Column.G = c("High",
-            "Medium", NA, "Low", "Low", "Medium", NA, "Medium",
-            "High", "High"), Column.H = rep(c(as.Date("2021-10-30"),
-            as.Date("2021-03-28"), NA), length = 10), Column.I = rep(c(as.POSIXlt("2021-10-31 03:00:00"),
-            as.POSIXlt(1582963631, origin = "1970-01-01"),
-            NA, as.POSIXlt("2001-12-31 23:59:59")), length = 10),
-        Column.J = rep(c(as.POSIXct("2021-10-31 03:00:00"),
-            as.POSIXct(1582963631, origin = "1970-01-01"),
-            NA, as.POSIXct("2001-12-31 23:59:59")), length = 10),
-        stringsAsFactors = FALSE)
-    cdf[["Column.F"]] <- factor(cdf[["Column.F"]])
-    cdf[["Column.F"]] <- ordered(cdf[["Column.F"]], levels = c("Low",
-        "Medium", "High"))
-    testDataFrame(file.xls, cdf)
-    testDataFrame(file.xlsx, cdf)
-    testClearSheets <- function(file, df) {
-        df.short <- df[1, ]
-        writeWorksheetToFile(file, data = c(df.short), sheet = "cdfRegion")
-        expect_equal(nrow(readWorksheetFromFile(file, sheet = "cdfRegion")),
-            nrow(df))
-        writeWorksheetToFile(file, data = c(df.short), sheet = "cdfRegion",
-            clearSheets = TRUE)
-        expect_equal(nrow(readWorksheetFromFile(file, sheet = "cdfRegion")),
-            1)
-    }
-    testClearSheets(file.xls, cdf)
-    testClearSheets(file.xlsx, cdf)
+
+    testDataFrame(attenu)
+    testDataFrame(ChickWeight)
+})
+
+test_that("clearSheets parameter works correctly for XLS", {
+    skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+    file.xls <- "testWriteWorksheetToFileWorkbook.xls"
+    on.exit(if (file.exists(file.xls)) file.remove(file.xls))
+
+    cdf <- data.frame(a = 1:10)
+    df.short <- cdf[1, , drop = FALSE]
+
+    writeWorksheetToFile(file.xls, data = df.short, sheet = "cdfRegion")
+    # expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(df.short))
+
+    writeWorksheetToFile(file.xls, data = cdf, sheet = "cdfRegion")
+    expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(cdf))
+
+    writeWorksheetToFile(file.xls, data = df.short, sheet = "cdfRegion", clearSheets = TRUE)
+    expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(df.short))
+})
+
+test_that("clearSheets parameter works correctly for XLSX", {
+    skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+    file.xlsx <- "testWriteWorksheetToFileWorkbook.xlsx"
+    on.exit(if (file.exists(file.xlsx)) file.remove(file.xlsx))
+
+    cdf <- data.frame(a = 1:10)
+    df.short <- cdf[1, , drop = FALSE]
+
+    writeWorksheetToFile(file.xlsx, data = df.short, sheet = "cdfRegion")
+    # expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(df.short))
+
+    writeWorksheetToFile(file.xlsx, data = cdf, sheet = "cdfRegion")
+    expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(cdf))
+
+    writeWorksheetToFile(file.xlsx, data = df.short, sheet = "cdfRegion", clearSheets = TRUE)
+    expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(df.short))
 })

--- a/tests/testthat/test.writeWorksheetToFile.R
+++ b/tests/testthat/test.writeWorksheetToFile.R
@@ -1,41 +1,132 @@
-test_that("writeWorksheetToFile writes and reads a data frame to/from an XLS file", {
+# TODO use subtests / parameterized tests when mature - see https://github.com/r-lib/testthat/issues/2063 and https://github.com/google/patrick/issues/20
+
+testDataFrame <- function(file, df) {
+    worksheet <- deparse(substitute(df))
+    print(paste("Writing dataset ", worksheet, "to file", file))
+    name <- paste(worksheet, "Region", sep = "")
+    writeWorksheetToFile(file, data = df, sheet = name)
+    res <- readWorksheetFromFile(file, sheet = name)
+    expect_equal(
+        normalizeDataframe(df),
+        res,
+        check.attributes = FALSE,
+    )
+}
+
+
+test_that("test.writeWorksheetToFile - full test suite only", {
     skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-    file.xls <- "testWriteWorksheetToFileWorkbook.xls"
-    on.exit(if (file.exists(file.xls)) file.remove(file.xls))
+    file.xls <- withr::local_tempfile(fileext = ".xls")
+    file.xlsx <- withr::local_tempfile(fileext = ".xlsx")
 
-    testDataFrame <- function(df) {
-        worksheet <- deparse(substitute(df))
-        name <- paste(worksheet, "Region", sep = "")
-        writeWorksheetToFile(file.xls, data = df, sheet = name)
-        res <- readWorksheetFromFile(file.xls, sheet = name)
-        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE)
-    }
-
-    testDataFrame(mtcars)
-    testDataFrame(airquality)
+    testDataFrame(file.xls, mtcars)
+    testDataFrame(file.xlsx, mtcars)
+    testDataFrame(file.xls, airquality)
+    testDataFrame(file.xlsx, airquality)
+    testDataFrame(file.xls, attenu)
+    testDataFrame(file.xlsx, attenu)
+    testDataFrame(file.xls, ChickWeight)
+    testDataFrame(file.xlsx, ChickWeight)
+    CO = CO2
+    testDataFrame(file.xls, CO2)
+    testDataFrame(file.xlsx, CO2)
+    testDataFrame(file.xls, iris)
+    testDataFrame(file.xlsx, iris)
+    testDataFrame(file.xls, longley)
+    testDataFrame(file.xlsx, longley)
+    testDataFrame(file.xls, morley)
+    testDataFrame(file.xlsx, morley)
+    testDataFrame(file.xls, swiss)
+    testDataFrame(file.xlsx, swiss)
+    cdf <- data.frame(
+        Column.A = c(1, 2, 3, NA, 5, 6, 7, 8, NA, 10),
+        Column.B = c(-4, -3, NA, -1, 0, NA, NA, 3, 4, 5),
+        Column.C = c(
+            "Anna",
+            "???",
+            NA,
+            "",
+            NA,
+            "$!?&%",
+            "(?2@?~?'^*#|)",
+            "{}[]:,;-_<>",
+            "\\sadf\n\nv",
+            "a b c"
+        ),
+        Column.D = c(
+            pi,
+            -pi,
+            NA,
+            sqrt(2),
+            sqrt(0.3),
+            -sqrt(pi),
+            exp(1),
+            log(2),
+            sin(2),
+            -tan(2)
+        ),
+        Column.E = c(TRUE, TRUE, NA, NA, FALSE, FALSE, TRUE, NA, FALSE, TRUE),
+        Column.F = c(
+            "High",
+            "Medium",
+            "Low",
+            "Low",
+            "Low",
+            NA,
+            NA,
+            "Medium",
+            "High",
+            "High"
+        ),
+        Column.G = c(
+            "High",
+            "Medium",
+            NA,
+            "Low",
+            "Low",
+            "Medium",
+            NA,
+            "Medium",
+            "High",
+            "High"
+        ),
+        Column.H = rep(
+            c(as.Date("2021-10-30"), as.Date("2021-03-28"), NA),
+            length = 10
+        ),
+        Column.I = rep(
+            c(
+                as.POSIXlt("2021-10-31 03:00:00"),
+                as.POSIXlt(1582963631, origin = "1970-01-01"),
+                NA,
+                as.POSIXlt("2001-12-31 23:59:59")
+            ),
+            length = 10
+        ),
+        Column.J = rep(
+            c(
+                as.POSIXct("2021-10-31 03:00:00"),
+                as.POSIXct(1582963631, origin = "1970-01-01"),
+                NA,
+                as.POSIXct("2001-12-31 23:59:59")
+            ),
+            length = 10
+        ),
+        stringsAsFactors = FALSE
+    )
+    cdf[["Column.F"]] <- factor(cdf[["Column.F"]])
+    cdf[["Column.F"]] <- ordered(
+        cdf[["Column.F"]],
+        levels = c("Low", "Medium", "High")
+    )
+    testDataFrame(file.xls, cdf)
+    testDataFrame(file.xlsx, cdf)
 })
 
-test_that("writeWorksheetToFile writes and reads a data frame to/from an XLSX file", {
-    skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-    file.xlsx <- "testWriteWorksheetToFileWorkbook.xlsx"
-    on.exit(if (file.exists(file.xlsx)) file.remove(file.xlsx))
-
-    testDataFrame <- function(df) {
-        worksheet <- deparse(substitute(df))
-        name <- paste(worksheet, "Region", sep = "")
-        writeWorksheetToFile(file.xlsx, data = df, sheet = name)
-        res <- readWorksheetFromFile(file.xlsx, sheet = name)
-        expect_equal(normalizeDataframe(df), res, ignore_attr = TRUE)
-    }
-
-    testDataFrame(attenu)
-    testDataFrame(ChickWeight)
-})
 
 test_that("clearSheets parameter works correctly for XLS", {
     skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-    file.xls <- "testWriteWorksheetToFileWorkbook.xls"
-    on.exit(if (file.exists(file.xls)) file.remove(file.xls))
+    file.xls <- withr::local_tempfile(fileext = ".xls")
 
     cdf <- data.frame(a = 1:10)
     df.short <- cdf[1, , drop = FALSE]
@@ -44,16 +135,27 @@ test_that("clearSheets parameter works correctly for XLS", {
     # expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(df.short))
 
     writeWorksheetToFile(file.xls, data = cdf, sheet = "cdfRegion")
-    expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(cdf))
+    expect_equal(
+        nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")),
+        nrow(cdf)
+    )
 
-    writeWorksheetToFile(file.xls, data = df.short, sheet = "cdfRegion", clearSheets = TRUE)
-    expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(df.short))
+    writeWorksheetToFile(
+        file.xls,
+        data = df.short,
+        sheet = "cdfRegion",
+        clearSheets = TRUE
+    )
+    expect_equal(
+        nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")),
+        nrow(df.short)
+    )
 })
+
 
 test_that("clearSheets parameter works correctly for XLSX", {
     skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-    file.xlsx <- "testWriteWorksheetToFileWorkbook.xlsx"
-    on.exit(if (file.exists(file.xlsx)) file.remove(file.xlsx))
+    file.xlsx <- withr::local_tempfile(fileext = ".xlsx")
 
     cdf <- data.frame(a = 1:10)
     df.short <- cdf[1, , drop = FALSE]
@@ -62,8 +164,19 @@ test_that("clearSheets parameter works correctly for XLSX", {
     # expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(df.short))
 
     writeWorksheetToFile(file.xlsx, data = cdf, sheet = "cdfRegion")
-    expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(cdf))
+    expect_equal(
+        nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")),
+        nrow(cdf)
+    )
 
-    writeWorksheetToFile(file.xlsx, data = df.short, sheet = "cdfRegion", clearSheets = TRUE)
-    expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(df.short))
+    writeWorksheetToFile(
+        file.xlsx,
+        data = df.short,
+        sheet = "cdfRegion",
+        clearSheets = TRUE
+    )
+    expect_equal(
+        nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")),
+        nrow(df.short)
+    )
 })


### PR DESCRIPTION
- split tests where feasible for smaller test units
- align attribute checking, only ignore attributes where needed
- use temporary files when creating to new files in tests