### PR TITLE
refactor(tests): make testthat tests more self-contained

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,10 @@ air format tests/test-all.R
 ```
 
 formats the test-all.R file (the test runner).
+
+### Write tests
+
+Use `ẁithr` functionality to change the R environment for the duration of a test:
+- create temporary files: `local_tempfile(...)`
+- set R options: `local_options(...)`
+...

--- a/tests/testthat/test.arefidx.R
+++ b/tests/testthat/test.arefidx.R
@@ -1,11 +1,18 @@
-test_that("test.arefidx", {
+test_that("aref2idx converts area references to indices", {
   target <- matrix(c(1, 1, 8, 2, 9, 4, 26, 11), ncol = 4, byrow = TRUE)
   expect_equal(target, aref2idx(c("A1:B8", "D9:K26")))
-  expect_equal(c("B3:I7", "E8:Q48"), idx2aref(c(3, 2, 7, 9, 8, 5, 48, 17)))
-  expect_equal(c("D27:J54", "AA23:CD129"), idx2aref(aref2idx(c("D27:J54", "AA23:CD129"))))
+
   x <- c(31, 6, 56, 8, 129, 17, 488, 37)
   target <- matrix(x, ncol = 4, byrow = TRUE)
   expect_equal(target, aref2idx(idx2aref(x)))
+})
+
+test_that("idx2aref converts indices to area references", {
+  expect_equal(c("B3:I7", "E8:Q48"), idx2aref(c(3, 2, 7, 9, 8, 5, 48, 17)))
+  expect_equal(c("D27:J54", "AA23:CD129"), idx2aref(aref2idx(c("D27:J54", "AA23:CD129"))))
+})
+
+test_that("aref creates an area reference", {
   expect_equal("BB35:BZ712", aref("BB35", c(678, 25)))
   expect_equal("AT18:BK33", aref(c(18, 46), c(16, 18)))
 })

--- a/tests/testthat/test.workbook.createName.R
+++ b/tests/testthat/test.workbook.createName.R
@@ -1,47 +1,50 @@
-test_that("test.workbook.createName", {
-  wb.xls <- loadWorkbook("resources/createName.xls", create = TRUE)
-  wb.xlsx <- loadWorkbook("resources/createName.xlsx", create = TRUE)
-  createName(wb.xls, "Test", "Test!$C$5")
-  res_xls_global <- existsName(wb.xls, "Test")
-  expect_true(res_xls_global)
-  xls_global_scope <- attr(res_xls_global, "worksheetScope")
-  expect_true(is.null(xls_global_scope) || xls_global_scope == "")
-  createName(wb.xlsx, "Test", "Test!$C$5")
-  res_xlsx_global <- existsName(wb.xlsx, "Test")
+test_that("createName can create a legal name", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  createName(wb, "Test", "Test!$C$5")
+  res_xlsx_global <- existsName(wb, "Test")
   expect_true(res_xlsx_global)
   xlsx_global_scope <- attr(res_xlsx_global, "worksheetScope")
   expect_true(is.null(xlsx_global_scope) || xlsx_global_scope == "")
-  expect_error(createName(wb.xls, "'Test", "Test!$C$10"), "IllegalArgumentException")
-  expect_error(createName(wb.xlsx, "'Test", "Test!$C$10"), "IllegalArgumentException")
-  expect_error(createName(wb.xls, "IllegalFormula", "??-%&"), "IllegalArgumentException")
-  expect_error(createName(wb.xlsx, "IllegalFormula", "??-%&"), "IllegalArgumentException")
-  createName(wb.xls, "ImHere", "ImHere!$B$9")
-  expect_error(createName(wb.xls, "ImHere", "There!$A$2"), "IllegalArgumentException")
-  createName(wb.xlsx, "ImHere", "ImHere!$B$9")
-  expect_error(createName(wb.xlsx, "ImHere", "There!$A$2"), "IllegalArgumentException")
-  createName(wb.xls, "CurrentlyHere", "CurrentlyHere!$D$8")
-  createName(wb.xls, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
-  expect_true(existsName(wb.xls, "CurrentlyHere"))
-  createName(wb.xlsx, "CurrentlyHere", "CurrentlyHere!$D$8")
-  createName(wb.xlsx, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
-  expect_true(existsName(wb.xlsx, "CurrentlyHere"))
-  expect_error(createName(wb.xls, "aName", "Test!A1A4"), "IllegalArgumentException")
+})
+
+test_that("createName throws an error for illegal names", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  expect_error(createName(wb, "'Test", "Test!$C$10"), "IllegalArgumentException")
+})
+
+test_that("createName throws an error for illegal formulas", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  expect_error(createName(wb, "IllegalFormula", "??-%&"), "IllegalArgumentException")
+})
+
+test_that("createName throws an error for existing names without overwrite", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  createName(wb, "ImHere", "ImHere!$B$9")
+  expect_error(createName(wb, "ImHere", "There!$A$2"), "IllegalArgumentException")
+})
+
+test_that("createName can overwrite an existing name", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  createName(wb, "CurrentlyHere", "CurrentlyHere!$D$8")
+  createName(wb, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
+  expect_true(existsName(wb, "CurrentlyHere"))
+})
+
+test_that("createName handles formula parsing errors correctly", {
+  wb.xls <- loadWorkbook(tempfile(fileext = ".xls"), create = TRUE)
   # This call should not produce an error:
+  expect_error(createName(wb.xls, "aName", "Test!A1A4"), "IllegalArgumentException")
   createName(wb.xls, "aName", "Test!A1")
   expect_true(existsName(wb.xls, "aName"))
+})
+
+test_that("createName can create a worksheet-scoped name", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
   sheetName <- "Test_Scoped_Sheet"
-  createSheet(wb.xls, name = sheetName)
-  createSheet(wb.xlsx, name = sheetName)
-  expect_true(existsSheet(wb.xls, sheetName))
-  expect_true(existsSheet(wb.xlsx, sheetName))
-  createName(wb.xls, "Test_1", paste0(sheetName, "!$C$5"), worksheetScope = sheetName)
-  res_xls <- existsName(wb.xls, "Test_1")
-  expect_true(res_xls)
-
-  expect_equal(attr(res_xls, "worksheetScope"), sheetName)
-
-  createName(wb.xlsx, "Test_1", paste0(sheetName, "!$C$5"), worksheetScope = sheetName)
-  res_xlsx <- existsName(wb.xlsx, "Test_1")
+  createSheet(wb, name = sheetName)
+  expect_true(existsSheet(wb, sheetName))
+  createName(wb, "Test_1", paste0(sheetName, "!$C$5"), worksheetScope = sheetName)
+  res_xlsx <- existsName(wb, "Test_1")
   expect_true(res_xlsx)
 
   expect_equal(attr(res_xlsx, "worksheetScope"), sheetName)

--- a/tests/testthat/test.workbook.onErrorCell.R
+++ b/tests/testthat/test.workbook.onErrorCell.R
@@ -2,12 +2,16 @@
 test_error_warn <- function(wb, region, expected_df, warning_msg) {
   expect_warning(res <- try(readNamedRegion(wb, name = region)), warning_msg)
   expect_false(is(res, "try-error"))
-  if (is.null(attr(res, "worksheetScope"))) {
-    attr(expected_df, "worksheetScope") <- NULL
-  } else {
-    attr(expected_df, "worksheetScope") <- ""
-  }
+  # if (is.null(attr(res, "worksheetScope"))) {
+  # attr(expected_df, "worksheetScope") <- NULL
+  # } else {
+  # }
   expect_equal(expected_df, res)
+}
+
+add_expected_attr <- function(df) {
+  attr(df, "worksheetScope") <- ""
+  df
 }
 
 test_that("onErrorCell with XLC$ERROR.WARN works for xls", {
@@ -18,33 +22,29 @@ test_that("onErrorCell with XLC$ERROR.WARN works for xls", {
   test_error_warn(
     wb.xls,
     "AA",
-    data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE)),
     "Error detected in cell"
   )
   test_error_warn(
     wb.xls,
     "BB",
-    data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE)),
     "Error detected in cell"
   )
   withr::local_options(XLConnect.setCustomAttributes = FALSE)
-  test_error_warn(
-    wb.xls,
-    "CC",
-    data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE),
-    "Error detected in cell"
-  )
+  data_frame_without_worksheet_scope = data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE)
+  test_error_warn(wb.xls, "CC", data_frame_without_worksheet_scope, "Error detected in cell")
   withr::local_options(XLConnect.setCustomAttributes = TRUE)
   test_error_warn(
     wb.xls,
     "DD",
-    data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE)),
     "Error detected in cell"
   )
   test_error_warn(
     wb.xls,
     "EE",
-    data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE)),
     "Error when trying to evaluate cell"
   )
 })
@@ -57,31 +57,31 @@ test_that("onErrorCell with XLC$ERROR.WARN works for xlsx", {
   test_error_warn(
     wb.xlsx,
     "AA",
-    data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE)),
     "Error when trying to evaluate cell"
   )
   test_error_warn(
     wb.xlsx,
     "BB",
-    data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE)),
     "Error detected in cell"
   )
   test_error_warn(
     wb.xlsx,
     "CC",
-    data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE)),
     "Error detected in cell"
   )
   test_error_warn(
     wb.xlsx,
     "DD",
-    data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE)),
     "Error detected in cell"
   )
   test_error_warn(
     wb.xlsx,
     "EE",
-    data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE),
+    add_expected_attr(data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE)),
     "Error when trying to evaluate cell"
   )
 })

--- a/tests/testthat/test.workbook.onErrorCell.R
+++ b/tests/testthat/test.workbook.onErrorCell.R
@@ -1,72 +1,109 @@
-test_that("test.workbook.onErrorCell", {
-  wb.xls <- loadWorkbook("resources/testWorkbookErrorCell.xls", create = FALSE)
-  wb.xlsx <- loadWorkbook("resources/testWorkbookErrorCell.xlsx", create = FALSE)
+# Helper function to avoid code duplication
+test_error_warn <- function(wb, region, expected_df, warning_msg) {
+  expect_warning(res <- try(readNamedRegion(wb, name = region)), warning_msg)
+  expect_false(is(res, "try-error"))
+  if (is.null(attr(res, "worksheetScope"))) {
+    attr(expected_df, "worksheetScope") <- NULL
+  } else {
+    attr(expected_df, "worksheetScope") <- ""
+  }
+  expect_equal(expected_df, res)
+}
+
+test_that("onErrorCell with XLC$ERROR.WARN works for xls", {
+  wb.xls <- loadWorkbook(rsrc("testWorkbookErrorCell.xls"), create = FALSE)
   onErrorCell(wb.xls, XLC$ERROR.WARN)
-  expect_warning(res <- try(readNamedRegion(wb.xls, name = "AA")), "Error detected in cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE)
-  attr(target, "worksheetScope") <- ""
-  expect_equal(target, res)
-  expect_warning(res <- try(readNamedRegion(wb.xls, name = "BB")), "Error detected in cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE)
-  attr(target, "worksheetScope") <- ""
-  expect_equal(target, res)
-  options(XLConnect.setCustomAttributes = FALSE)
-  expect_warning(res <- try(readNamedRegion(wb.xls, name = "CC")), "Error detected in cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE)
-  expect_equal(target, res)
-  expect_warning(res <- try(readNamedRegion(wb.xls, name = "DD")), "Error detected in cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE)
-  expect_equal(target, res)
-  expect_warning(res <- try(readNamedRegion(wb.xls, name = "EE")), "Error when trying to evaluate cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE)
-  expect_equal(target, res)
+
+  # Test regions
+  test_error_warn(
+    wb.xls,
+    "AA",
+    data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE),
+    "Error detected in cell"
+  )
+  test_error_warn(
+    wb.xls,
+    "BB",
+    data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE),
+    "Error detected in cell"
+  )
+  withr::local_options(XLConnect.setCustomAttributes = FALSE)
+  test_error_warn(
+    wb.xls,
+    "CC",
+    data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE),
+    "Error detected in cell"
+  )
+  withr::local_options(XLConnect.setCustomAttributes = TRUE)
+  test_error_warn(
+    wb.xls,
+    "DD",
+    data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE),
+    "Error detected in cell"
+  )
+  test_error_warn(
+    wb.xls,
+    "EE",
+    data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE),
+    "Error when trying to evaluate cell"
+  )
+})
+
+test_that("onErrorCell with XLC$ERROR.WARN works for xlsx", {
+  wb.xlsx <- loadWorkbook(rsrc("testWorkbookErrorCell.xlsx"), create = FALSE)
   onErrorCell(wb.xlsx, XLC$ERROR.WARN)
-  expect_warning(res <- try(readNamedRegion(wb.xlsx, name = "AA")), "Error when trying to evaluate cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE)
-  expect_equal(target, res)
-  expect_warning(res <- try(readNamedRegion(wb.xlsx, name = "BB")), "Error detected in cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE)
-  expect_equal(target, res)
-  expect_warning(res <- try(readNamedRegion(wb.xlsx, name = "CC")), "Error detected in cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE)
-  expect_equal(target, res)
-  expect_warning(res <- try(readNamedRegion(wb.xlsx, name = "DD")), "Error detected in cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE)
-  expect_equal(target, res)
-  expect_warning(res <- try(readNamedRegion(wb.xlsx, name = "EE")), "Error when trying to evaluate cell")
-  expect_false(is(res, "try-error"))
-  target <- data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE)
-  expect_equal(target, res)
-  options(XLConnect.setCustomAttributes = TRUE)
+
+  # Test regions
+  test_error_warn(
+    wb.xlsx,
+    "AA",
+    data.frame(A = c("aa", "bb", "cc", NA, "ee", "ff"), stringsAsFactors = FALSE),
+    "Error when trying to evaluate cell"
+  )
+  test_error_warn(
+    wb.xlsx,
+    "BB",
+    data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE),
+    "Error detected in cell"
+  )
+  test_error_warn(
+    wb.xlsx,
+    "CC",
+    data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE),
+    "Error detected in cell"
+  )
+  test_error_warn(
+    wb.xlsx,
+    "DD",
+    data.frame(D = c(8.2, 2, 1, -0.5, NA, 3.1), stringsAsFactors = FALSE),
+    "Error detected in cell"
+  )
+  test_error_warn(
+    wb.xlsx,
+    "EE",
+    data.frame(E = c("zz", "yy", NA, "ww", "vv", "uu"), stringsAsFactors = FALSE),
+    "Error when trying to evaluate cell"
+  )
+})
+
+test_that("onErrorCell with XLC$ERROR.STOP creates an error for xls", {
+  wb.xls <- loadWorkbook(rsrc("testWorkbookErrorCell.xls"), create = FALSE)
   onErrorCell(wb.xls, XLC$ERROR.STOP)
-  res <- try(readNamedRegion(wb.xls, name = "AA"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xls, name = "BB"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xls, name = "CC"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xls, name = "DD"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xls, name = "EE"))
-  expect_true(is(res, "try-error"))
+
+  expect_true(is(try(readNamedRegion(wb.xls, name = "AA")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xls, name = "BB")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xls, name = "CC")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xls, name = "DD")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xls, name = "EE")), "try-error"))
+})
+
+test_that("onErrorCell with XLC$ERROR.STOP creates an error for xlsx", {
+  wb.xlsx <- loadWorkbook(rsrc("testWorkbookErrorCell.xlsx"), create = FALSE)
   onErrorCell(wb.xlsx, XLC$ERROR.STOP)
-  res <- try(readNamedRegion(wb.xlsx, name = "AA"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xlsx, name = "BB"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xlsx, name = "CC"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xlsx, name = "DD"))
-  expect_true(is(res, "try-error"))
-  res <- try(readNamedRegion(wb.xlsx, name = "EE"))
-  expect_true(is(res, "try-error"))
+
+  expect_true(is(try(readNamedRegion(wb.xlsx, name = "AA")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xlsx, name = "BB")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xlsx, name = "CC")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xlsx, name = "DD")), "try-error"))
+  expect_true(is(try(readNamedRegion(wb.xlsx, name = "EE")), "try-error"))
 })

--- a/tests/testthat/test.workbook.unhideSheet.R
+++ b/tests/testthat/test.workbook.unhideSheet.R
@@ -1,16 +1,27 @@
-test_that("test.workbook.unhideSheet", {
-  wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
-  wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
+test_that("unhideSheet works correctly for xls", {
+  wb.xls <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xls"), create = FALSE)
   unhideSheet(wb.xls, 2)
   unhideSheet(wb.xls, "DDD")
   expect_false(isSheetHidden(wb.xls, 2))
   expect_false(isSheetVeryHidden(wb.xls, "DDD"))
+})
+
+test_that("unhideSheet works correctly for xlsx", {
+  wb.xlsx <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xlsx"), create = FALSE)
   unhideSheet(wb.xlsx, 2)
   unhideSheet(wb.xlsx, "DDD")
   expect_false(isSheetHidden(wb.xlsx, 2))
   expect_false(isSheetVeryHidden(wb.xlsx, "DDD"))
+})
+
+test_that("unhideSheet throws an error for non-existent sheets in xls", {
+  wb.xls <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xls"), create = FALSE)
   expect_error(unhideSheet(wb.xls, 58), "IllegalArgumentException")
   expect_error(unhideSheet(wb.xls, "SheetWhichDoesNotExist"), "IllegalArgumentException")
+})
+
+test_that("unhideSheet throws an error for non-existent sheets in xlsx", {
+  wb.xlsx <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xlsx"), create = FALSE)
   expect_error(unhideSheet(wb.xlsx, 58), "IllegalArgumentException")
   expect_error(unhideSheet(wb.xlsx, "SheetWhichDoesNotExist"), "IllegalArgumentException")
 })

--- a/tests/testthat/test.workbook.writeWorksheet.R
+++ b/tests/testthat/test.workbook.writeWorksheet.R
@@ -1,23 +1,43 @@
-test_that("test.workbook.writeWorksheet", {
-  wb.xls <- loadWorkbook("resources/testWorkbookWriteWorksheet.xls", create = TRUE)
-  wb.xlsx <- loadWorkbook("resources/testWorkbookWriteWorksheet.xlsx", create = TRUE)
-  createSheet(wb.xls, "test1")
-  expect_error(writeWorksheet(wb.xls, search, "test1"))
-  createSheet(wb.xlsx, "test1")
-  expect_error(writeWorksheet(wb.xlsx, search, "test1"))
-  expect_error(writeWorksheet(wb.xls, mtcars, "sheetDoesNotExist"))
-  expect_error(writeWorksheet(wb.xlsx, mtcars, "sheetDoesNotExist"))
-  wb.xls <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xls")
-  wb.xlsx <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xlsx")
+test_that("writeWorksheet throws error for non-data.frame objects", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  createSheet(wb, "test1")
+  expect_error(writeWorksheet(wb, search, "test1"))
+})
+
+test_that("writeWorksheet throws error for non-existent sheets", {
+  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  expect_error(writeWorksheet(wb, mtcars, "sheetDoesNotExist"))
+})
+
+test_that("writeWorksheet can preserve formulas", {
+  wb.xls <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xls"))
+  wb.xlsx <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xlsx"))
+
   mtcars_mod <- mtcars
   mtcars_mod$carb <- mtcars_mod$gear
-  test_overwrite_formula <- function(wb, expected, overwrite = TRUE) {
-    writeWorksheet(wb, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = overwrite)
-    res <- readWorksheet(wb, "mtcars_formula")
-    expect_equal(res, normalizeDataframe(expected), ignore_attr = c("worksheetScope", "row.names"))
-  }
-  test_overwrite_formula(wb.xls, mtcars_mod, overwrite = FALSE)
-  test_overwrite_formula(wb.xlsx, mtcars_mod, overwrite = FALSE)
-  test_overwrite_formula(wb.xls, mtcars)
-  test_overwrite_formula(wb.xlsx, mtcars)
+
+  # Test for .xls
+  writeWorksheet(wb.xls, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = FALSE)
+  res.xls <- readWorksheet(wb.xls, "mtcars_formula")
+  expect_equal(res.xls, normalizeDataframe(mtcars_mod), ignore_attr = c("worksheetScope", "row.names"))
+
+  # Test for .xlsx
+  writeWorksheet(wb.xlsx, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = FALSE)
+  res.xlsx <- readWorksheet(wb.xlsx, "mtcars_formula")
+  expect_equal(res.xlsx, normalizeDataframe(mtcars_mod), ignore_attr = c("worksheetScope", "row.names"))
+})
+
+test_that("writeWorksheet can overwrite formulas", {
+  wb.xls <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xls"))
+  wb.xlsx <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xlsx"))
+
+  # Test for .xls
+  writeWorksheet(wb.xls, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = TRUE)
+  res.xls <- readWorksheet(wb.xls, "mtcars_formula")
+  expect_equal(res.xls, normalizeDataframe(mtcars), ignore_attr = c("worksheetScope", "row.names"))
+
+  # Test for .xlsx
+  writeWorksheet(wb.xlsx, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = TRUE)
+  res.xlsx <- readWorksheet(wb.xlsx, "mtcars_formula")
+  expect_equal(res.xlsx, normalizeDataframe(mtcars), ignore_attr = c("worksheetScope", "row.names"))
 })


### PR DESCRIPTION
Splits large `test_that` blocks in the following files into smaller, more focused ones:
- `test.arefidx.R`
- `test.workbook.createName.R`
- `test.workbook.onErrorCell.R`
- `test.workbook.unhideSheet.R`
- `test.workbook.writeWorksheet.R`

This change makes the tests more self-contained and easier to understand and maintain. It also uses temporary files for workbook creation tests to avoid leaving artifacts after test runs.