### PR TITLE
Refactor uses of tempfile to withr::local_tempfile in tests

### DIFF
--- a/tests/testthat/test.loadWorkbook.R
+++ b/tests/testthat/test.loadWorkbook.R
@@ -12,9 +12,7 @@ test_that("loading existing valid XLS and XLSX files works", {
 })
 
 test_that("creating a new XLS file on the fly works", {
-  file_to_create_xls <- rsrc("fileCreatedOnTheFly.xls")
-  on.exit(if (file.exists(file_to_create_xls)) file.remove(file_to_create_xls))
-
+  file_to_create_xls <- withr::local_tempfile(fileext = ".xls")
   wb_create_xls <- loadWorkbook(file_to_create_xls, create = TRUE)
   expect_true(is(wb_create_xls, "workbook"))
   saveWorkbook(wb_create_xls, file_to_create_xls)
@@ -22,9 +20,7 @@ test_that("creating a new XLS file on the fly works", {
 })
 
 test_that("creating a new XLSX file on the fly works", {
-  file_to_create_xlsx <- rsrc("fileCreatedOnTheFly.xlsx")
-  on.exit(if (file.exists(file_to_create_xlsx)) file.remove(file_to_create_xlsx))
-
+  file_to_create_xlsx <- withr::local_tempfile(fileext = ".xlsx")
   wb_create_xlsx <- loadWorkbook(file_to_create_xlsx, create = TRUE)
   expect_true(is(wb_create_xlsx, "workbook"))
   saveWorkbook(wb_create_xlsx, file_to_create_xlsx)

--- a/tests/testthat/test.workbook.createName.R
+++ b/tests/testthat/test.workbook.createName.R
@@ -1,5 +1,5 @@
 test_that("createName can create a legal name", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   createName(wb, "Test", "Test!$C$5")
   res_xlsx_global <- existsName(wb, "Test")
   expect_true(res_xlsx_global)
@@ -8,30 +8,30 @@ test_that("createName can create a legal name", {
 })
 
 test_that("createName throws an error for illegal names", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   expect_error(createName(wb, "'Test", "Test!$C$10"), "IllegalArgumentException")
 })
 
 test_that("createName throws an error for illegal formulas", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   expect_error(createName(wb, "IllegalFormula", "??-%&"), "IllegalArgumentException")
 })
 
 test_that("createName throws an error for existing names without overwrite", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   createName(wb, "ImHere", "ImHere!$B$9")
   expect_error(createName(wb, "ImHere", "There!$A$2"), "IllegalArgumentException")
 })
 
 test_that("createName can overwrite an existing name", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   createName(wb, "CurrentlyHere", "CurrentlyHere!$D$8")
   createName(wb, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
   expect_true(existsName(wb, "CurrentlyHere"))
 })
 
 test_that("createName handles formula parsing errors correctly", {
-  wb.xls <- loadWorkbook(tempfile(fileext = ".xls"), create = TRUE)
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
   # This call should not produce an error:
   expect_error(createName(wb.xls, "aName", "Test!A1A4"), "IllegalArgumentException")
   createName(wb.xls, "aName", "Test!A1")
@@ -39,7 +39,7 @@ test_that("createName handles formula parsing errors correctly", {
 })
 
 test_that("createName can create a worksheet-scoped name", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   sheetName <- "Test_Scoped_Sheet"
   createSheet(wb, name = sheetName)
   expect_true(existsSheet(wb, sheetName))

--- a/tests/testthat/test.workbook.saveWorkbook.R
+++ b/tests/testthat/test.workbook.saveWorkbook.R
@@ -1,7 +1,6 @@
 test_that("saveWorkbook saves an XLS file", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-  file.xls <- "testWorkbookSaveWorkbook.xls"
-  on.exit(if (file.exists(file.xls)) file.remove(file.xls))
+  file.xls <- withr::local_tempfile(fileext = ".xls")
 
   wb.xls <- loadWorkbook(file.xls, create = TRUE)
   expect_false(file.exists(file.xls))
@@ -11,8 +10,7 @@ test_that("saveWorkbook saves an XLS file", {
 
 test_that("saveWorkbook saves an XLSX file", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-  file.xlsx <- "testWorkbookSaveWorkbook.xlsx"
-  on.exit(if (file.exists(file.xlsx)) file.remove(file.xlsx))
+  file.xlsx <- withr::local_tempfile(fileext = ".xlsx")
 
   wb.xlsx <- loadWorkbook(file.xlsx, create = TRUE)
   expect_false(file.exists(file.xlsx))
@@ -22,14 +20,8 @@ test_that("saveWorkbook saves an XLSX file", {
 
 test_that("saveWorkbook saves an XLS file to a new location", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-  file.xls <- "testWorkbookSaveWorkbook.xls"
-  newFile.xls <- "saveAsWorkbook.xls"
-  on.exit({
-    if (file.exists(file.xls)) {
-      file.remove(file.xls)
-    }
-    if (file.exists(newFile.xls)) file.remove(newFile.xls)
-  })
+  file.xls <- withr::local_tempfile(fileext = ".xls")
+  newFile.xls <- withr::local_tempfile(fileext = ".xls")
 
   wb.xls <- loadWorkbook(file.xls, create = TRUE)
   saveWorkbook(wb.xls, file = newFile.xls)
@@ -38,14 +30,8 @@ test_that("saveWorkbook saves an XLS file to a new location", {
 
 test_that("saveWorkbook saves an XLSX file to a new location", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
-  file.xlsx <- "testWorkbookSaveWorkbook.xlsx"
-  newFile.xlsx <- "saveAsWorkbook.xlsx"
-  on.exit({
-    if (file.exists(file.xlsx)) {
-      file.remove(file.xlsx)
-    }
-    if (file.exists(newFile.xlsx)) file.remove(newFile.xlsx)
-  })
+  file.xlsx <- withr::local_tempfile(fileext = ".xlsx")
+  newFile.xlsx <- withr::local_tempfile(fileext = ".xlsx")
 
   wb.xlsx <- loadWorkbook(file.xlsx, create = TRUE)
   saveWorkbook(wb.xlsx, file = newFile.xlsx)

--- a/tests/testthat/test.workbook.writeWorksheet.R
+++ b/tests/testthat/test.workbook.writeWorksheet.R
@@ -1,11 +1,11 @@
 test_that("writeWorksheet throws error for non-data.frame objects", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   createSheet(wb, "test1")
   expect_error(writeWorksheet(wb, search, "test1"))
 })
 
 test_that("writeWorksheet throws error for non-existent sheets", {
-  wb <- loadWorkbook(tempfile(fileext = ".xlsx"), create = TRUE)
+  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   expect_error(writeWorksheet(wb, mtcars, "sheetDoesNotExist"))
 })
 


### PR DESCRIPTION
This commit refactors the test files in `tests/testthat` to use `withr::local_tempfile` instead of `base::tempfile`. This is a best practice for creating temporary files in tests, as `withr` handles the cleanup automatically.

The following files were modified:
- `tests/testthat/test.loadWorkbook.R`
- `tests/testthat/test.workbook.createName.R`
- `tests/testthat/test.workbook.writeWorksheet.R`
- `tests/testthat/test.workbook.saveWorkbook.R`