### PR TITLE
feat: Transfer comments from runit to testthat

### DIFF
--- a/tests/testthat/test.arefidx.R
+++ b/tests/testthat/test.arefidx.R
@@ -12,7 +12,7 @@ test_that("idx2aref converts indices to area references", {
   expect_equal(c("D27:J54", "AA23:CD129"), idx2aref(aref2idx(c("D27:J54", "AA23:CD129"))))
 })
 
-test_that("aref creates an area reference", {
+test_that("aref creates an area reference from top-left position and dimensions", {
   expect_equal("BB35:BZ712", aref("BB35", c(678, 25)))
   expect_equal("AT18:BK33", aref(c(18, 46), c(16, 18)))
 })

--- a/tests/testthat/test.colidx.R
+++ b/tests/testthat/test.colidx.R
@@ -6,11 +6,11 @@ test_that("idx2col converts indices to column names", {
   expect_equal(c("A", "AA", "HZR"), idx2col(c(1, 27, 6102)))
 })
 
-test_that("col2idx and idx2col are inverse functions", {
+test_that("idx2col and col2idx are inverse functions", {
   expect_equal(c("AWT", "FRT"), idx2col(col2idx(c("AWT", "FRT"))))
   expect_equal(c(3628, 867), col2idx(idx2col(c(3628, 867))))
 })
 
-test_that("idx2col handles invalid indices", {
+test_that("idx2col handles invalid indices by returning empty strings", {
   expect_equal(rep("", 3), idx2col(c(0, -1, -2628)))
 })

--- a/tests/testthat/test.configurePOI.R
+++ b/tests/testthat/test.configurePOI.R
@@ -1,11 +1,21 @@
 test_that("test.configurePOI", {
+  # Check that an exception is thrown if we limit the number of files to just 1
   configurePOI(zip_max_files = 1L)
   expect_error(loadWorkbook("resources/testLoadWorkbook.xlsx"))
+
+  # Check zip bomb detection with high inflate ratio
   configurePOI(zip_min_inflate_ratio = 0.99)
   expect_error(readWorksheetFromFile("resources/testZipBomb.xlsx", sheet = 1))
+
+  # Check that an exception is thrown if we limit the max zip entry size to just
+  # 1 byte
   configurePOI(zip_max_entry_size = 1L)
   expect_error(readWorksheetFromFile("resources/testWorkbookReadWorksheet.xlsx", sheet = 1))
+
+  # Check storing of zip entries in temp files
   configurePOI(zip_entry_threshold_bytes = 0L)
   readWorksheetFromFile("resources/testWorkbookReadWorksheet.xlsx", sheet = 1)
+
+  # Reset settings after test
   configurePOI()
 })

--- a/tests/testthat/test.configurePOI.R
+++ b/tests/testthat/test.configurePOI.R
@@ -1,21 +1,23 @@
-test_that("test.configurePOI", {
-  # Check that an exception is thrown if we limit the number of files to just 1
+test_that("exception is thrown if zip_max_files is set to 1", {
   configurePOI(zip_max_files = 1L)
   expect_error(loadWorkbook("resources/testLoadWorkbook.xlsx"))
+  configurePOI()
+})
 
-  # Check zip bomb detection with high inflate ratio
+test_that("zip bomb detection works with high inflate ratio", {
   configurePOI(zip_min_inflate_ratio = 0.99)
   expect_error(readWorksheetFromFile("resources/testZipBomb.xlsx", sheet = 1))
+  configurePOI()
+})
 
-  # Check that an exception is thrown if we limit the max zip entry size to just
-  # 1 byte
+test_that("exception is thrown if zip_max_entry_size is set to 1 byte", {
   configurePOI(zip_max_entry_size = 1L)
   expect_error(readWorksheetFromFile("resources/testWorkbookReadWorksheet.xlsx", sheet = 1))
+  configurePOI()
+})
 
-  # Check storing of zip entries in temp files
+test_that("zip entries are stored in temp files when zip_entry_threshold_bytes is 0", {
   configurePOI(zip_entry_threshold_bytes = 0L)
-  readWorksheetFromFile("resources/testWorkbookReadWorksheet.xlsx", sheet = 1)
-
-  # Reset settings after test
+  expect_true(is.data.frame(readWorksheetFromFile("resources/testWorkbookReadWorksheet.xlsx", sheet = 1)))
   configurePOI()
 })

--- a/tests/testthat/test.configurePOI.R
+++ b/tests/testthat/test.configurePOI.R
@@ -1,23 +1,36 @@
-test_that("exception is thrown if zip_max_files is set to 1", {
+test_that("exception is thrown if we limit the number of files to just 1", {
+  # Check that an exception is thrown if we limit the number of files to just 1
   configurePOI(zip_max_files = 1L)
   expect_error(loadWorkbook("resources/testLoadWorkbook.xlsx"))
+
+  # Reset settings after test
   configurePOI()
 })
 
 test_that("zip bomb detection works with high inflate ratio", {
+  # Check zip bomb detection with high inflate ratio
   configurePOI(zip_min_inflate_ratio = 0.99)
   expect_error(readWorksheetFromFile("resources/testZipBomb.xlsx", sheet = 1))
+
+  # Reset settings after test
   configurePOI()
 })
 
-test_that("exception is thrown if zip_max_entry_size is set to 1 byte", {
+test_that("exception is thrown if we limit the max zip entry size to just 1 byte", {
+  # Check that an exception is thrown if we limit the max zip entry size to just
+  # 1 byte
   configurePOI(zip_max_entry_size = 1L)
   expect_error(readWorksheetFromFile("resources/testWorkbookReadWorksheet.xlsx", sheet = 1))
+
+  # Reset settings after test
   configurePOI()
 })
 
 test_that("zip entries are stored in temp files when zip_entry_threshold_bytes is 0", {
+  # Check storing of zip entries in temp files
   configurePOI(zip_entry_threshold_bytes = 0L)
   expect_true(is.data.frame(readWorksheetFromFile("resources/testWorkbookReadWorksheet.xlsx", sheet = 1)))
+
+  # Reset settings after test
   configurePOI()
 })

--- a/tests/testthat/test.crefidx.R
+++ b/tests/testthat/test.crefidx.R
@@ -1,4 +1,4 @@
-test_that("test.crefidx", {
+test_that("Tests around converting Excel cell references to row & column indices", {
   target <- matrix(c(5, 8, 14, 38), ncol = 2, byrow = TRUE)
   expect_equal(target, cref2idx(c("$H$5", "$AL$14")))
   expect_equal(c("$H$5", "$AL$14"), idx2cref(c(5, 8, 14, 38)))

--- a/tests/testthat/test.dataframeConversion.R
+++ b/tests/testthat/test.dataframeConversion.R
@@ -1,8 +1,10 @@
-test_that("test.dataframeConversion - always run", {
+test_that("dataframe conversion - Tests whether data.frame's pushed and pulled to/from Java are consistent (with respect to some defined differences; see 'normalizeDataframe') - always run", {
   testDataFrame <- function(df) {
     res <- XLConnect:::dataframeFromJava(XLConnect:::dataframeToJava(df), check.names = TRUE)
     expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope"))
   }
+
+  # custom test dataset
   cdf <- data.frame(
     Column.A = c(1, 2, 3, NA, 5, Inf, 7, 8, NA, 10),
     Column.B = c(-4, -3, NA, -Inf, 0, NA, NA, 3, 4, 5),
@@ -37,14 +39,20 @@ test_that("test.dataframeConversion - always run", {
   cdf[["Column.F"]] <- factor(cdf[["Column.F"]])
   cdf[["Column.F"]] <- ordered(cdf[["Column.F"]], levels = c("Low", "Medium", "High"))
   testDataFrame(cdf)
+
+  # Check that when being supplied with an object that is not coercable
+  # into a data.frame, an appropriate exception is thrown
   expect_error(XLConnect:::dataframeToJava(search))
+
+  # Check that exceptions are thrown when calling dataframeFromJava
+  # with inappropriate objects
   expect_error(XLConnect:::dataframeFromJava(NULL))
   expect_error(XLConnect:::dataframeFromJava(NA))
   expect_error(XLConnect:::dataframeFromJava(9))
   expect_error(XLConnect:::dataframeFromJava(search))
 })
 
-test_that("test.dataframeConversion - full test suite only", {
+test_that("dataframe conversion - built-in datasets - full test suite only", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
 
   testDataFrame <- function(df) {

--- a/tests/testthat/test.dataframeConversion.R
+++ b/tests/testthat/test.dataframeConversion.R
@@ -12,6 +12,7 @@ test_that("test.dataframeConversion - always run", {
     Column.F = c("High", "Medium", "Low", "Low", "Low", NA, NA, "Medium", "High", "High"),
     Column.G = c("High", "Medium", NA, "Low", "Low", "Medium", NA, "Medium", "High", "High"),
     Column.H = rep(c(as.Date("2021-10-30"), as.Date("2021-03-28"), NA), length = 10),
+    # NOTE: Column.I is automatically converted to POSIXct!!!
     Column.I = rep(
       c(
         as.POSIXlt("2021-10-31 03:00:00"),
@@ -21,6 +22,7 @@ test_that("test.dataframeConversion - always run", {
       ),
       length = 10
     ),
+    # NOTE: 1582963631 with origin="1970-01-01" corresponds to 2020 Feb 29
     Column.J = rep(
       c(
         as.POSIXct("2021-10-31 03:00:00"),

--- a/tests/testthat/test.dumpAndRestore.R
+++ b/tests/testthat/test.dumpAndRestore.R
@@ -1,4 +1,4 @@
-test_that("test.dumpAndRestore - full test suite only", {
+test_that("dumping & restoring objects to/from Excel files - full test suite only", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
 
   require(datasets)

--- a/tests/testthat/test.dumpAndRestore.R
+++ b/tests/testthat/test.dumpAndRestore.R
@@ -3,6 +3,8 @@ test_that("test.dumpAndRestore - full test suite only", {
 
   require(datasets)
   pos = "package:datasets"
+
+  # Get all data.frame's from 'package:datasets'
   objs = ls(pos = pos)
   idx = sapply(objs, function(obj) is.data.frame(get(obj, pos = pos)))
   objs = objs[idx]

--- a/tests/testthat/test.loadWorkbook.R
+++ b/tests/testthat/test.loadWorkbook.R
@@ -44,6 +44,7 @@ test_that("loading a password-protected file (testBug61.xlsx) works", {
 })
 
 test_that("loading a password-protected file (testBug106.xlsx) works", {
+  # Excel2019
   pwdProtectedFile2 <- rsrc("testBug106.xlsx")
   expect_error(
     loadWorkbook(pwdProtectedFile2),
@@ -59,7 +60,7 @@ test_that("loading a password-protected file (testBug106.xlsx) works", {
   expect_true(is(wb_pwd2, "workbook"))
 })
 
-test_that("loading a file relative to the working directory works", {
+test_that("loading a file relative to the working directory works (#212)", {
   setwd(rsrc(""))
   wb_direct_name <- loadWorkbook("testLoadWorkbook.xls") # avoid using rsrc here, as it creates an absolute path
   expect_true(is(wb_direct_name, "workbook"))

--- a/tests/testthat/test.loadWorkbook.R
+++ b/tests/testthat/test.loadWorkbook.R
@@ -1,17 +1,28 @@
 test_that("loading non-existent files throws an error", {
+  # Check that an exception is thrown when trying to open
+  # a non-existent file (*.xls)
   expect_error(loadWorkbook(rsrc("fileWhichDoesNotExist.xls")))
+
+  # Check that an exception is thrown when trying to open
+  # a non-existent file (*.xlsx)
   expect_error(loadWorkbook(rsrc("fileWhichDoesNotExist.xlsx")))
 })
 
 test_that("loading existing valid XLS and XLSX files works", {
+  # Check that an instance of the workbook class is returned
+  # for an already existing file (*.xls)
   wb_xls <- loadWorkbook(rsrc("testLoadWorkbook.xls"))
   expect_true(is(wb_xls, "workbook"))
 
+  # Check that an instance of the workbook class is returned
+  # for an already existing file (*.xlsx)
   wb_xlsx <- loadWorkbook(rsrc("testLoadWorkbook.xlsx"))
   expect_true(is(wb_xlsx, "workbook"))
 })
 
 test_that("creating a new XLS file on the fly works", {
+  # Check that an instance of the workbook class is returned
+  # for a file created on-the-fly (*.xls)
   file_to_create_xls <- withr::local_tempfile(fileext = ".xls")
   wb_create_xls <- loadWorkbook(file_to_create_xls, create = TRUE)
   expect_true(is(wb_create_xls, "workbook"))
@@ -20,6 +31,8 @@ test_that("creating a new XLS file on the fly works", {
 })
 
 test_that("creating a new XLSX file on the fly works", {
+  # Check that an instance of the workbook class is returned
+  # for a file created on-the-fly (*.xlsx)
   file_to_create_xlsx <- withr::local_tempfile(fileext = ".xlsx")
   wb_create_xlsx <- loadWorkbook(file_to_create_xlsx, create = TRUE)
   expect_true(is(wb_create_xlsx, "workbook"))
@@ -29,38 +42,59 @@ test_that("creating a new XLSX file on the fly works", {
 
 test_that("loading a password-protected file (testBug61.xlsx) works", {
   pwdProtectedFile1 <- rsrc("testBug61.xlsx")
+
+  # Check that opening a password protected file throws an error
+  # if no password is specified
   expect_error(
     loadWorkbook(pwdProtectedFile1),
     "EncryptedDocumentException (Java): The supplied spreadsheet is protected, but no password was supplied",
     fixed = TRUE
   )
+
+  # Check that opening a password protected file throws an error
+  # if a wrong password is specified
   expect_error(
     loadWorkbook(pwdProtectedFile1, password = "wrong"),
     "EncryptedDocumentException (Java): Password incorrect",
     fixed = TRUE
   )
+
+  # Check that a password protected file can be opened if the
+  # correct password is specified
   wb_pwd1 <- loadWorkbook(pwdProtectedFile1, password = "mirai")
   expect_true(is(wb_pwd1, "workbook"))
 })
 
 test_that("loading a password-protected file (testBug106.xlsx) works", {
-  # Excel2019
   pwdProtectedFile2 <- rsrc("testBug106.xlsx")
+
+  # Check that opening a password protected file throws an error
+  # if no password is specified
+  # Excel2019
   expect_error(
     loadWorkbook(pwdProtectedFile2),
     "EncryptedDocumentException (Java): The supplied spreadsheet is protected, but no password was supplied",
     fixed = TRUE
   )
+
+  # Check that opening a password protected file throws an error
+  # if a wrong password is specified
+  # Excel2019
   expect_error(
     loadWorkbook(pwdProtectedFile2, password = "wrong"),
     "EncryptedDocumentException (Java): Password incorrect",
     fixed = TRUE
   )
+
+  # Check that a password protected file can be opened if the
+  # correct password is specified
+  # Excel2019
   wb_pwd2 <- loadWorkbook(pwdProtectedFile2, password = "mirai")
   expect_true(is(wb_pwd2, "workbook"))
 })
 
 test_that("loading a file relative to the working directory works (#212)", {
+  # Check that loadWorkbook can handle relative paths (#212)
   setwd(rsrc(""))
   wb_direct_name <- loadWorkbook("testLoadWorkbook.xls") # avoid using rsrc here, as it creates an absolute path
   expect_true(is(wb_direct_name, "workbook"))

--- a/tests/testthat/test.with.workbook.R
+++ b/tests/testthat/test.with.workbook.R
@@ -1,4 +1,4 @@
-test_that("with.workbook correctly loads data from an XLS file", {
+test_that("with.workbook correctly loads data from an XLS file - check if named regions can be correctly referenced", {
   wb.xls <- loadWorkbook(rsrc("testWithWorkbook.xls"), create = FALSE)
   with(
     wb.xls,
@@ -10,7 +10,7 @@ test_that("with.workbook correctly loads data from an XLS file", {
   )
 })
 
-test_that("with.workbook correctly loads data from an XLSX file", {
+test_that("with.workbook correctly loads data from an XLSX file - check if named regions can be correctly referenced", {
   wb.xlsx <- loadWorkbook(rsrc("testWithWorkbook.xlsx"), create = FALSE)
   with(
     wb.xlsx,

--- a/tests/testthat/test.workbook.appendNamedRegion.R
+++ b/tests/testthat/test.workbook.appendNamedRegion.R
@@ -15,13 +15,13 @@ test_overwrite_formula_helper <- function(
   expect_equal(getReferenceCoordinatesForName(wb, name_to_use), expected_coords)
 }
 
-test_that("appending to an existing named region works for XLS and XLSX", {
+test_that("appending data to a named region produces the expected result", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookAppend.xls"))
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookAppend.xlsx"))
 
-  refCoord <- matrix(c(9, 5, 73, 15), ncol = 2, byrow = TRUE) # Expected coordinates after appending mtcars once
+  refCoord <- matrix(c(9, 5, 73, 15), ncol = 2, byrow = TRUE)
 
-  # XLS
+  # Check that appending data to a named region produces the expected result (*.xls)
   appendNamedRegion(wb.xls, mtcars, name = "mtcars")
   res_xls <- readNamedRegion(wb.xls, name = "mtcars")
   rownames(res_xls) <- as.character(seq_len(nrow(res_xls)))
@@ -30,7 +30,7 @@ test_that("appending to an existing named region works for XLS and XLSX", {
   expect_equal(normalizeDataframe(expected_data_xls), normalizeDataframe(res_xls))
   expect_equal(refCoord, getReferenceCoordinatesForName(wb.xls, "mtcars"))
 
-  # XLSX
+  # Check that appending data to a named region produces the expected result (*.xlsx)
   appendNamedRegion(wb.xlsx, mtcars, name = "mtcars")
   res_xlsx <- readNamedRegion(wb.xlsx, name = "mtcars")
   rownames(res_xlsx) <- as.character(seq_len(nrow(res_xlsx)))
@@ -40,18 +40,22 @@ test_that("appending to an existing named region works for XLS and XLSX", {
   expect_equal(refCoord, getReferenceCoordinatesForName(wb.xlsx, "mtcars"))
 })
 
-test_that("appending to a non-existent named region throws an error", {
+test_that("trying to append to a non-existing named region throws an error", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookAppend.xls"))
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookAppend.xlsx"))
 
+  # Check that trying to append to an non-existing named region throws an error (*.xls)
   expect_error(appendNamedRegion(wb.xls, mtcars, name = "doesNotExist"))
+
+  # Check that trying to append to an non-existing named region throws an error (*.xlsx)
   expect_error(appendNamedRegion(wb.xlsx, mtcars, name = "doesNotExist"))
 })
 
-test_that("overwriteFormulaCells = FALSE works as expected", {
+test_that("appending data to a named region with a formula below it does not overwrite it if overwriteFormulaCells is set to FALSE", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookAppend.xls")) # Reload fresh workbook
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookAppend.xlsx")) # Reload fresh workbook
 
+  # Initialize mtcars_mod as is defined with the formula in the carb column (set equal to the gear column)
   mtcars_mod <- mtcars
   mtcars_mod$carb <- mtcars_mod$gear
 
@@ -61,6 +65,8 @@ test_that("overwriteFormulaCells = FALSE works as expected", {
   expected_data_overwrite_false <- rbind(mtcars_mod, mtcars_carb_eq_gear)
   expected_coords_overwrite_false <- matrix(c(9, 5, 73, 15), ncol = 2, byrow = TRUE)
 
+  # Check that appending data to a named region with a formula below it does not overwrite it if
+  # overwriteFormulaCells is set to FALSE (*.xls)
   test_overwrite_formula_helper(
     wb.xls,
     mtcars,
@@ -69,6 +75,9 @@ test_that("overwriteFormulaCells = FALSE works as expected", {
     name_to_use = "mtcars_formula",
     overwrite = FALSE
   )
+
+  # Check that appending data to a named region with a formula below it does not overwrite it if
+  # overwriteFormulaCells is set to FALSE (*.xlsx)
   test_overwrite_formula_helper(
     wb.xlsx,
     mtcars,
@@ -79,7 +88,8 @@ test_that("overwriteFormulaCells = FALSE works as expected", {
   )
 })
 
-test_that("overwriteFormulaCells = TRUE works as expected", {
+test_that("appending data to a named region with a formula below it overwrites it if overwriteFormulaCells is set to TRUE (default)", {
+  # Re-create workbooks
   wb.xls <- loadWorkbook(rsrc("testWorkbookAppend.xls"))
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookAppend.xlsx"))
 
@@ -92,6 +102,8 @@ test_that("overwriteFormulaCells = TRUE works as expected", {
   expected_data_overwrite_true <- rbind(mtcars_mod, mtcars)
   expected_coords_overwrite_true <- matrix(c(9, 5, 73, 15), ncol = 2, byrow = TRUE)
 
+  # Check that appending data to a named region with a formula below it overwrites it if
+  # overwriteFormulaCells is set to TRUE (default) (*.xls)
   test_overwrite_formula_helper(
     wb.xls,
     mtcars,
@@ -100,6 +112,9 @@ test_that("overwriteFormulaCells = TRUE works as expected", {
     name_to_use = "mtcars_formula",
     overwrite = TRUE
   )
+
+  # Check that appending data to a named region with a formula below it overwrites it if
+  # overwriteFormulaCells is set to TRUE (default) (*.xlsx)
   test_overwrite_formula_helper(
     wb.xlsx,
     mtcars,
@@ -111,12 +126,14 @@ test_that("overwriteFormulaCells = TRUE works as expected", {
 })
 
 
-test_that("appending different data (airquality) to 'mtcars' named region updates coordinates", {
+test_that("appending data to a named region with a different structure results in the correct bounding box for the re-defined named region", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookAppend.xls"))
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookAppend.xlsx"))
 
   refCoord_airquality_append <- matrix(c(9, 5, 194, 15), ncol = 2, byrow = TRUE)
 
+  # Check that appending data to a named region with a different structure results
+  # in the correct bounding box for the re-defined named region (*.xls)
   appendNamedRegion(wb.xls, airquality, name = "mtcars")
   expect_equal(refCoord_airquality_append, getReferenceCoordinatesForName(wb.xls, "mtcars"))
 
@@ -124,6 +141,8 @@ test_that("appending different data (airquality) to 'mtcars' named region update
   res_xls_air <- readNamedRegion(wb.xls, name = "mtcars")
   expect_equal(nrow(res_xls_air), 32 + nrow(airquality))
 
+  # Check that appending data to a named region with a different structure results
+  # in the correct bounding box for the re-defined named region (*.xlsx)
   appendNamedRegion(wb.xlsx, airquality, name = "mtcars")
   expect_equal(refCoord_airquality_append, getReferenceCoordinatesForName(wb.xlsx, "mtcars"))
 

--- a/tests/testthat/test.workbook.appendWorksheet.R
+++ b/tests/testthat/test.workbook.appendWorksheet.R
@@ -1,6 +1,9 @@
 test_that("test.workbook.appendWorksheet", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookAppend.xls")
   wb.xlsx <- loadWorkbook("resources/testWorkbookAppend.xlsx")
+
+  # Check that appending data to a worksheet produces the expected result (*.xls)
   appendWorksheet(wb.xls, mtcars, sheet = "mtcars")
   res <- readWorksheet(wb.xls, sheet = "mtcars")
   rownames(res) <- as.character(seq_len(nrow(res)))
@@ -8,6 +11,8 @@ test_that("test.workbook.appendWorksheet", {
   expected_data_xls <- rbind(mtcars, mtcars)
   rownames(expected_data_xls) <- as.character(seq_len(nrow(expected_data_xls)))
   expect_equal(normalizeDataframe(expected_data_xls), normalizeDataframe(res))
+
+  # Check that appending data to a named region produces the expected result (*.xlsx)
   appendWorksheet(wb.xlsx, mtcars, sheet = "mtcars")
   res <- readWorksheet(wb.xlsx, sheet = "mtcars")
   rownames(res) <- as.character(seq_len(nrow(res)))
@@ -15,6 +20,10 @@ test_that("test.workbook.appendWorksheet", {
   expected_data_xlsx <- rbind(mtcars, mtcars)
   rownames(expected_data_xlsx) <- as.character(seq_len(nrow(expected_data_xlsx)))
   expect_equal(normalizeDataframe(expected_data_xlsx), normalizeDataframe(res))
+
+  # Check that trying to append to an non-existing worksheet throws an error (*.xls)
   expect_error(appendWorksheet(wb.xls, mtcars, sheet = "doesNotExist"), "IllegalArgumentException")
+
+  # Check that trying to append to an non-existing worksheet throws an error (*.xlsx)
   expect_error(appendWorksheet(wb.xlsx, mtcars, sheet = "doesNotExist"), "IllegalArgumentException")
 })

--- a/tests/testthat/test.workbook.cellstyles.R
+++ b/tests/testthat/test.workbook.cellstyles.R
@@ -1,5 +1,6 @@
 context("Workbook Cell Style Functionality")
 
+
 test_that("Basic cell style operations (create, exists, get) work as expected", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE for cellstyle tests")
 
@@ -11,23 +12,28 @@ test_that("Basic cell style operations (create, exists, get) work as expected", 
 
   styleName <- "MyStyle"
 
-  # Initial state: style should not exist
+  # Check that a cell style which hasn't been created yet does not exist
   expect_false(existsCellStyle(wb.xls, styleName))
   expect_false(existsCellStyle(wb.xlsx, styleName))
+
+  # Using getCellStyle is expected to through an exception
   expect_error(getCellStyle(wb.xls, styleName), "IllegalArgumentException", info = "XLS: Getting non-existent style")
   expect_error(getCellStyle(wb.xlsx, styleName), "IllegalArgumentException", info = "XLSX: Getting non-existent style")
 
-  # Create style
+  # Check that a cell style can be created
   createCellStyle(wb.xls, styleName)
   createCellStyle(wb.xlsx, styleName)
+
+  # Check that a cell style which has been created exists
   expect_true(existsCellStyle(wb.xls, styleName), info = "XLS: Style should exist after creation")
   expect_true(existsCellStyle(wb.xlsx, styleName), info = "XLSX: Style should exist after creation")
 
-  # Attempting to create an existing style should error
+  # Attempting to create a cell style which already exists is expected
+  # to throw an exception
   expect_error(createCellStyle(wb.xls, styleName), "IllegalArgumentException", info = "XLS: Creating existing style")
   expect_error(createCellStyle(wb.xlsx, styleName), "IllegalArgumentException", info = "XLSX: Creating existing style")
 
-  # Getting an existing style should work
+  # Check that a cell style which has been created can be retrieved
   cs_xls <- getCellStyle(wb.xls, styleName)
   expect_true(is(cs_xls, "cellstyle"), info = "XLS: getCellStyle should return a cellstyle object")
   cs_xlsx <- getCellStyle(wb.xlsx, styleName)
@@ -45,23 +51,20 @@ test_that("getOrCreateCellStyle works as expected", {
 
   anotherStyleName <- "MyOtherStyle"
 
-  # Style does not exist initially
+  # Check creation and retrieval of cell styles using getOrCreateCellStyle
   expect_false(existsCellStyle(wb.xls, anotherStyleName))
   expect_false(existsCellStyle(wb.xlsx, anotherStyleName))
 
-  # getOrCreateCellStyle when style does not exist
   cs_xls_new <- getOrCreateCellStyle(wb.xls, anotherStyleName)
   expect_true(is(cs_xls_new, "cellstyle"), info = "XLS: getOrCreate (new) should return cellstyle")
-  expect_true(existsCellStyle(wb.xls, anotherStyleName), info = "XLS: Style should exist after getOrCreate (new)")
-
   cs_xlsx_new <- getOrCreateCellStyle(wb.xlsx, anotherStyleName)
   expect_true(is(cs_xlsx_new, "cellstyle"), info = "XLSX: getOrCreate (new) should return cellstyle")
+
+  expect_true(existsCellStyle(wb.xls, anotherStyleName), info = "XLS: Style should exist after getOrCreate (new)")
   expect_true(existsCellStyle(wb.xlsx, anotherStyleName), info = "XLSX: Style should exist after getOrCreate (new)")
 
-  # getOrCreateCellStyle when style already exists
   cs_xls_existing <- getOrCreateCellStyle(wb.xls, anotherStyleName)
   expect_true(is(cs_xls_existing, "cellstyle"), info = "XLS: getOrCreate (existing) should return cellstyle")
-
   cs_xlsx_existing <- getOrCreateCellStyle(wb.xlsx, anotherStyleName)
   expect_true(is(cs_xlsx_existing, "cellstyle"), info = "XLSX: getOrCreate (existing) should return cellstyle")
 })

--- a/tests/testthat/test.workbook.clearNamedRegion.R
+++ b/tests/testthat/test.workbook.clearNamedRegion.R
@@ -11,18 +11,30 @@ test_that("test.workbook.clearNamedRegion", {
     seven = 31:35,
     stringsAsFactors = F
   )
+
+  # Check that clearing 2 of 3 named regions in a sheet returns only the third one (*.xls)
   clearNamedRegion(wb.xls, c("region1", "region2"))
   res <- readWorksheet(wb.xls, "clearNamedRegion", header = TRUE)
   expect_equal(checkDf, res)
+
+  # Check that clearing 2 of 3 named regions in a sheet returns only the third one (*.xlsx)
   clearNamedRegion(wb.xlsx, c("region1", "region2"))
   res <- readWorksheet(wb.xlsx, "clearNamedRegion", header = TRUE)
   expect_equal(checkDf, res)
+
+  # reset
   wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx", create = FALSE)
+
+  # check that specifying the worksheet name doesn't find globally scoped names
   expect_error(clearNamedRegion(wb.xls, c("region1", "region2"), worksheetScope = "clearNamedRegion"))
+
+  # Check that clearing 2 of 3 named regions in a sheet returns only the third one (*.xls)
   clearNamedRegion(wb.xls, c("region1", "region2"))
   res <- readWorksheet(wb.xls, "clearNamedRegion", header = TRUE)
   expect_equal(checkDf, res)
+
+  # Check that clearing 2 of 3 named regions in a sheet returns only the third one (*.xlsx)
   clearNamedRegion(wb.xlsx, c("region1", "region2"))
   res <- readWorksheet(wb.xlsx, "clearNamedRegion", header = TRUE)
   expect_equal(checkDf, res)

--- a/tests/testthat/test.workbook.clearRange.R
+++ b/tests/testthat/test.workbook.clearRange.R
@@ -1,4 +1,5 @@
 test_that("clearRange works correctly for XLS", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls", create = FALSE)
   checkDf <- data.frame(
     one = 1:5,
@@ -10,12 +11,15 @@ test_that("clearRange works correctly for XLS", {
     seven = 31:35,
     stringsAsFactors = F
   )
+
+  # Check that clearing ranges returns the desired result (*.xls)
   clearRange(wb.xls, "clearRange", c(c(4, 4, 5, 5), c(6, 7, 7, 8)))
   res <- readWorksheet(wb.xls, "clearRange", region = "C3:I8", header = TRUE)
   expect_equal(checkDf, res)
 })
 
 test_that("clearRange works correctly for XLSX", {
+  # Create workbooks
   wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx", create = FALSE)
   checkDf <- data.frame(
     one = 1:5,
@@ -27,6 +31,8 @@ test_that("clearRange works correctly for XLSX", {
     seven = 31:35,
     stringsAsFactors = F
   )
+
+  # Check that clearing ranges returns the desired result (*.xlsx)
   clearRange(wb.xlsx, "clearRange", c(c(4, 4, 5, 5), c(6, 7, 7, 8)))
   res <- readWorksheet(wb.xlsx, "clearRange", region = "C3:I8", header = TRUE)
   expect_equal(checkDf, res)

--- a/tests/testthat/test.workbook.clearRangeFromReference.R
+++ b/tests/testthat/test.workbook.clearRangeFromReference.R
@@ -1,5 +1,7 @@
-test_that("clearRangeFromReference works correctly for XLS", {
+test_that("clearing ranges from references in an Excel Workbook works correctly for XLS", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls", create = FALSE)
+
   checkDf <- data.frame(
     one = 1:5,
     two = c(NA, NA, 8, 9, 10),
@@ -10,13 +12,17 @@ test_that("clearRangeFromReference works correctly for XLS", {
     seven = 31:35,
     stringsAsFactors = F
   )
+
+  # Check that clearing ranges from references returns the desired result (*.xls)
   clearRangeFromReference(wb.xls, c("clearRangeFromReference!D4:E5", "clearRangeFromReference!G6:H7"))
   res <- readWorksheet(wb.xls, "clearRangeFromReference", region = "C3:I8", header = TRUE)
   expect_equal(checkDf, res)
 })
 
-test_that("clearRangeFromReference works correctly for XLSX", {
+test_that("clearing ranges from references in an Excel Workbook works correctly for XLSX", {
+  # Create workbooks
   wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx", create = FALSE)
+
   checkDf <- data.frame(
     one = 1:5,
     two = c(NA, NA, 8, 9, 10),
@@ -27,6 +33,8 @@ test_that("clearRangeFromReference works correctly for XLSX", {
     seven = 31:35,
     stringsAsFactors = F
   )
+
+  # Check that clearing ranges from references returns the desired result (*.xlsx)
   clearRangeFromReference(wb.xlsx, c("clearRangeFromReference!D4:E5", "clearRangeFromReference!G6:H7"))
   res <- readWorksheet(wb.xlsx, "clearRangeFromReference", region = "C3:I8", header = TRUE)
   expect_equal(checkDf, res)

--- a/tests/testthat/test.workbook.clearSheet.R
+++ b/tests/testthat/test.workbook.clearSheet.R
@@ -1,13 +1,19 @@
-test_that("clearSheet works correctly for XLS", {
+test_that("clearing sheets returns empty sheets (*.xls)", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookClearCells.xls", create = FALSE)
+
+  # Check that clearing sheets returns empty sheets (*.xls)
   clearSheet(wb.xls, c("clearSheet1", "clearSheet2"))
   res1 <- getLastRow(wb.xls, "clearSheet1")
   res2 <- getLastRow(wb.xls, "clearSheet2")
   expect_equal(c(clearSheet1 = 1, clearSheet2 = 1), c(res1, res2))
 })
 
-test_that("clearSheet works correctly for XLSX", {
+test_that("clearing sheets returns empty sheets (*.xlsx)", {
+  # Create workbooks
   wb.xlsx <- loadWorkbook("resources/testWorkbookClearCells.xlsx", create = FALSE)
+
+  # Check that clearing sheets returns empty sheets (*.xlsx)
   clearSheet(wb.xlsx, c("clearSheet1", "clearSheet2"))
   res1 <- getLastRow(wb.xlsx, "clearSheet1")
   res2 <- getLastRow(wb.xlsx, "clearSheet2")

--- a/tests/testthat/test.workbook.cloneSheet.R
+++ b/tests/testthat/test.workbook.cloneSheet.R
@@ -1,16 +1,25 @@
-test_that("test.workbook.cloneSheet", {
+test_that("cloning Excel worksheets", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookCloneSheet.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookCloneSheet.xlsx", create = FALSE)
-  # cloneSheet does not throw an error if successful
+
+  # Check cloning of worksheet (*.xls)
   cloneSheet(wb.xls, sheet = "Test1", name = "Clone1")
-  # readWorksheet does not throw an error if successful
   readWorksheet(wb.xls, sheet = "Clone1")
-  # cloneSheet does not throw an error if successful
+
+  # Check cloning of worksheet (*.xlsx)
   cloneSheet(wb.xlsx, sheet = "Test1", name = "Clone1")
-  # readWorksheet does not throw an error if successful
   readWorksheet(wb.xlsx, sheet = "Clone1")
+
+  # Check that attempting to clone a non-existing worksheet throws an exception (*.xls)
   expect_error(cloneSheet(wb.xls, sheet = "NotThere", name = "MyClone"), "IllegalArgumentException")
+
+  # Check that attempting to clone a non-existing worksheet throws an exception (*.xlsx)
   expect_error(cloneSheet(wb.xlsx, sheet = "NotThere", name = "MyClone"), "IllegalArgumentException")
+
+  # Check that attempting to assign an invalid name to a cloned sheet throws an exception (*.xls)
   expect_error(cloneSheet(wb.xls, sheet = "Test1", name = "'illegal"), "IllegalArgumentException")
+
+  # Check that attempting to assign an invalid name to a cloned sheet throws an exception (*.xlsx)
   expect_error(cloneSheet(wb.xlsx, sheet = "Test1", name = "'illegal"), "IllegalArgumentException")
 })

--- a/tests/testthat/test.workbook.createName.R
+++ b/tests/testthat/test.workbook.createName.R
@@ -1,58 +1,129 @@
-test_that("createName can create a legal name", {
+test_that("createName can create a legal name (*.xls)", {
+  # Check that creating a legal name works ok (*.xls)
   # (this test assumes 'existsName' is working fine)
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
-  createName(wb, "Test", "Test!$C$5")
-  res_xlsx_global <- existsName(wb, "Test")
-  expect_true(res_xlsx_global)
-  xlsx_global_scope <- attr(res_xlsx_global, "worksheetScope")
-  expect_true(is.null(xlsx_global_scope) || xlsx_global_scope == "")
-})
-
-test_that("createName throws an error for illegal names", {
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
-  expect_error(createName(wb, "'Test", "Test!$C$10"), "IllegalArgumentException")
-})
-
-test_that("createName throws an error for illegal formulas", {
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
-  expect_error(createName(wb, "IllegalFormula", "??-%&"), "IllegalArgumentException")
-})
-
-test_that("createName throws an error for existing names without overwrite", {
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
-  createName(wb, "ImHere", "ImHere!$B$9")
-  expect_error(createName(wb, "ImHere", "There!$A$2"), "IllegalArgumentException")
-})
-
-test_that("createName can overwrite an existing name", {
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
-  createName(wb, "CurrentlyHere", "CurrentlyHere!$D$8")
-  createName(wb, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
-  # TODO: Should actually rather check that new formula is correct
-  expect_true(existsName(wb, "CurrentlyHere"))
-})
-
-test_that("createName handles formula parsing errors correctly", {
   wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
-  # This call should not produce an error:
-  expect_error(createName(wb.xls, "aName", "Test!A1A4"), "IllegalArgumentException")
+  createName(wb.xls, "Test", "Test!$C$5")
+  expect_true(existsName(wb.xls, "Test"))
+})
+
+test_that("createName can create a legal name (*.xlsx)", {
+  # Check that creating a legal name works ok (*.xlsx)
+  # (this test assumes 'existsName' is working fine)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  createName(wb.xlsx, "Test", "Test!$C$5")
+  expect_true(existsName(wb.xlsx, "Test"))
+})
+
+test_that("createName throws an error for illegal names (*.xls)", {
+  # Check that trying to create an illegal name throws
+  # an exception (*.xls)
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
+  expect_error(createName(wb.xls, "'Test", "Test!$C$10"))
+})
+
+test_that("createName throws an error for illegal names (*.xlsx)", {
+  # Check that trying to create an illegal name throws
+  # an exception (*.xlsx)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  expect_error(createName(wb.xlsx, "'Test", "Test!$C$10"))
+})
+
+test_that("createName throws an error for illegal formulas (*.xls)", {
+  # Check that trying to create a name with an illegal formula
+  # throws an exception (*.xls)
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
+  expect_error(createName(wb.xls, "IllegalFormula", "??-%&"))
+})
+
+test_that("createName throws an error for illegal formulas (*.xlsx)", {
+  # Check that trying to create a name with an illegal formula
+  # throws an exception (*.xlsx)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  expect_error(createName(wb.xlsx, "IllegalFormula", "??-%&"))
+})
+
+test_that("createName throws an error for existing names without overwrite (*.xls)", {
+  # Check that trying to create an already existing name without
+  # specifying 'overwrite = TRUE' throws an exception (*.xls)
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
+  createName(wb.xls, "ImHere", "ImHere!$B$9")
+  expect_error(createName(wb.xls, "ImHere", "There!$A$2"))
+})
+
+test_that("createName throws an error for existing names without overwrite (*.xlsx)", {
+  # Check that trying to create an already existing name without
+  # specifying 'overwrite = TRUE' throws an exception (*.xlsx)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  createName(wb.xlsx, "ImHere", "ImHere!$B$9")
+  expect_error(createName(wb.xlsx, "ImHere", "There!$A$2"))
+})
+
+test_that("createName can overwrite an existing name (*.xls)", {
+  # Check that overwriting an existing name works ok (*.xls)
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
+  createName(wb.xls, "CurrentlyHere", "CurrentlyHere!$D$8")
+  createName(wb.xls, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
+  # TODO: Should actually rather check that new formula is correct
+  expect_true(existsName(wb.xls, "CurrentlyHere"))
+})
+
+test_that("createName can overwrite an existing name (*.xlsx)", {
+  # Check that overwriting an existing name works ok (*.xlsx)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  createName(wb.xlsx, "CurrentlyHere", "CurrentlyHere!$D$8")
+  createName(wb.xlsx, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
+  # TODO: Should actually rather check that new formula is correct
+  expect_true(existsName(wb.xlsx, "CurrentlyHere"))
+})
+
+test_that("createName handles formula parsing errors correctly (*.xls)", {
+  # Check that after trying to write a name with an illegal formula
+  # (which throws an exception), the name remains available (*.xls)
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
+  expect_error(createName(wb.xls, "aName", "Test!A1A4"))
   createName(wb.xls, "aName", "Test!A1")
   expect_true(existsName(wb.xls, "aName"))
-
-  # NOTE: This seems to have changed with POI 3.11-beta1 - creating a
-  # name with an invalid formula does not throw an exception anymore!
 })
 
-test_that("createName can create a worksheet-scoped name", {
+test_that("createName handles formula parsing errors correctly (*.xlsx)", {
+  # Check that after trying to write a name with an illegal formula
+  # (which throws an exception), the name remains available (*.xlsx)
+  #
+  # NOTE: This seems to have changed with POI 3.11-beta1 - creating a
+  # name with an invalid formula does not throw an exception anymore!
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  # checkException(createName(wb.xlsx, "aName", "Test!A1A4"))
+  # checkNoException(createName(wb.xlsx, "aName", "Test!A1"))
+  # checkEquals(existsName(wb.xlsx, "aName"), TRUE, check.attributes = FALSE)
+})
+
+test_that("createName can create a worksheet-scoped name (*.xls)", {
+  # Check that creating a worksheet-scoped name works (*.xls)
   # we first need to create a worksheet:
   # global names can be created without an existing sheet, but not scoped ones.
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
   sheetName <- "Test_Scoped_Sheet"
-  createSheet(wb, name = sheetName)
-  expect_true(existsSheet(wb, sheetName))
-  createName(wb, "Test_1", paste0(sheetName, "!$C$5"), worksheetScope = sheetName)
-  res_xlsx <- existsName(wb, "Test_1")
-  expect_true(res_xlsx)
 
-  expect_equal(attr(res_xlsx, "worksheetScope"), sheetName)
+  createSheet(wb.xls, name = sheetName)
+  expect_true(existsSheet(wb.xls, sheetName))
+
+  expect_found = TRUE
+  attr(expect_found, "worksheetScope") <- sheetName
+  createName(wb.xls, "Test_1", "Test!$C$5", worksheetScope = sheetName)
+  expect_equal(existsName(wb.xls, "Test_1"), expect_found)
+})
+
+test_that("createName can create a worksheet-scoped name (*.xlsx)", {
+  # Check that creating a worksheet-scoped name works (*.xlsx)
+  # (this test assumes 'existsName' is working fine)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+  sheetName <- "Test_Scoped_Sheet"
+
+  createSheet(wb.xlsx, name = sheetName)
+  expect_true(existsSheet(wb.xlsx, sheetName))
+
+  expect_found = TRUE
+  attr(expect_found, "worksheetScope") <- sheetName
+  createName(wb.xlsx, "Test_1", "Test!$C$5", worksheetScope = sheetName)
+  expect_equal(existsName(wb.xlsx, "Test_1"), expect_found)
 })

--- a/tests/testthat/test.workbook.createName.R
+++ b/tests/testthat/test.workbook.createName.R
@@ -1,4 +1,5 @@
 test_that("createName can create a legal name", {
+  # (this test assumes 'existsName' is working fine)
   wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   createName(wb, "Test", "Test!$C$5")
   res_xlsx_global <- existsName(wb, "Test")
@@ -27,6 +28,7 @@ test_that("createName can overwrite an existing name", {
   wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   createName(wb, "CurrentlyHere", "CurrentlyHere!$D$8")
   createName(wb, "CurrentlyHere", "NowThere!$C$3", overwrite = TRUE)
+  # TODO: Should actually rather check that new formula is correct
   expect_true(existsName(wb, "CurrentlyHere"))
 })
 
@@ -36,9 +38,14 @@ test_that("createName handles formula parsing errors correctly", {
   expect_error(createName(wb.xls, "aName", "Test!A1A4"), "IllegalArgumentException")
   createName(wb.xls, "aName", "Test!A1")
   expect_true(existsName(wb.xls, "aName"))
+
+  # NOTE: This seems to have changed with POI 3.11-beta1 - creating a
+  # name with an invalid formula does not throw an exception anymore!
 })
 
 test_that("createName can create a worksheet-scoped name", {
+  # we first need to create a worksheet:
+  # global names can be created without an existing sheet, but not scoped ones.
   wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
   sheetName <- "Test_Scoped_Sheet"
   createSheet(wb, name = sheetName)

--- a/tests/testthat/test.workbook.createSheet.R
+++ b/tests/testthat/test.workbook.createSheet.R
@@ -1,14 +1,32 @@
 test_that("createSheet throws an error for invalid sheet names in XLS", {
   wb.xls <- loadWorkbook("resources/createSheet.xls", create = TRUE)
+
+  # Check that an exception is thrown when trying to create
+  # a worksheet with a single quote at the beginning (*.xls)
   expect_error(createSheet(wb.xls, "'Invalid Sheet Name"), "IllegalArgumentException")
+
+  # Check that an exception is thrown when trying to create
+  # a worksheet with a single quote at the end (*.xls)
   expect_error(createSheet(wb.xls, "Invalid Sheet Name'"), "IllegalArgumentException")
+
+  # Check that an exception is thrown when trying to create
+  # a worksheet with a very long name (> 31 characters) (*.xls)
   expect_error(createSheet(wb.xls, "A very very very very very very very very long name"), "IllegalArgumentException")
 })
 
 test_that("createSheet throws an error for invalid sheet names in XLSX", {
   wb.xlsx <- loadWorkbook("resources/createSheet.xlsx", create = TRUE)
+
+  # Check that an exception is thrown when trying to create
+  # a worksheet with a single quote at the beginning (*.xlsx)
   expect_error(createSheet(wb.xlsx, "'Invalid Sheet Name"), "IllegalArgumentException")
+
+  # Check that an exception is thrown when trying to create
+  # a worksheet with a single quote at the end (*.xlsx)
   expect_error(createSheet(wb.xlsx, "Invalid Sheet Name'"), "IllegalArgumentException")
+
+  # Check that an exception is thrown when trying to create
+  # a worksheet with a very long name (> 31 characters) (*.xlsx)
   expect_error(createSheet(wb.xlsx, "A very very very very very very very very long name"), "IllegalArgumentException")
 })
 
@@ -17,9 +35,13 @@ test_that("createSheet works for valid sheet names in XLS and XLSX", {
   wb.xlsx <- loadWorkbook("resources/createSheet.xlsx", create = TRUE)
   sheetName <- "My Sheet"
 
+  # Check if creating a legal worksheet is working properly (*.xls)
+  # (assumes method existsSheet working properly)
   createSheet(wb.xls, sheetName)
   expect_true(existsSheet(wb.xls, sheetName))
 
+  # Check if creating a legal worksheet is working properly (*.xlsx)
+  # (assumes method existsSheet working properly)
   createSheet(wb.xlsx, sheetName)
   expect_true(existsSheet(wb.xlsx, sheetName))
 })
@@ -29,11 +51,15 @@ test_that("creating an existing sheet is a NOP in XLS and XLSX", {
   wb.xlsx <- loadWorkbook("resources/createSheet.xlsx", create = TRUE)
   sheetName <- "My Sheet"
 
+  # Trying to create an already existing sheet should not cause
+  # any issues (just skips) (*.xls)
   createSheet(wb.xls, sheetName) # First time
   expect_true(existsSheet(wb.xls, sheetName))
   createSheet(wb.xls, sheetName) # Second time
   expect_true(existsSheet(wb.xls, sheetName))
 
+  # Trying to create an already existing sheet should not cause
+  # any issues (just skips) (*.xlsx)
   createSheet(wb.xlsx, sheetName) # First time
   expect_true(existsSheet(wb.xlsx, sheetName))
   createSheet(wb.xlsx, sheetName) # Second time

--- a/tests/testthat/test.workbook.existsName.R
+++ b/tests/testthat/test.workbook.existsName.R
@@ -1,4 +1,5 @@
 test_that("existsName identifies global names in XLS", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
   res_xls_AA <- existsName(wb.xls, "AA")
   expect_true(res_xls_AA)
@@ -16,12 +17,14 @@ test_that("existsName identifies global names in XLS", {
 
 test_that("existsName identifies non-existent and illegal names in XLS", {
   wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
+  # Check that the following do NOT exists (*.xls)
   expect_false(existsName(wb.xls, "DD"))
   expect_false(existsName(wb.xls, "'illegal name"))
   expect_false(existsName(wb.xls, "%&$$-^~@afk20 235-??a?"))
 })
 
 test_that("existsName identifies global names in XLSX", {
+  # Create workbooks
   wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
   res_xlsx_AA <- existsName(wb.xlsx, "AA")
   expect_true(res_xlsx_AA)
@@ -39,6 +42,7 @@ test_that("existsName identifies global names in XLSX", {
 
 test_that("existsName identifies non-existent and illegal names in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
+  # Check that the following do NOT exists (*.xlsx)
   expect_false(existsName(wb.xlsx, "DD"))
   expect_false(existsName(wb.xlsx, "'illegal name"))
   expect_false(existsName(wb.xlsx, "%&$$-^~@afk20 235-??a?"))
@@ -46,6 +50,7 @@ test_that("existsName identifies non-existent and illegal names in XLSX", {
 
 test_that("existsName identifies sheet-scoped names in XLS", {
   wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
+  # check with attributes - where was the name found ? (*.xls)
   res_xls_AA_1 <- existsName(wb.xls, "AA_1")
   expect_true(res_xls_AA_1)
   if (isTRUE(getOption("XLConnect.setCustomAttributes"))) {
@@ -60,6 +65,7 @@ test_that("existsName identifies sheet-scoped names in XLS", {
 
 test_that("existsName identifies sheet-scoped names in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
+  # check with attributes - where was the name found ? (*.xlsx)
   res_xlsx_AA_1 <- existsName(wb.xlsx, "AA_1")
   expect_true(res_xlsx_AA_1)
   if (isTRUE(getOption("XLConnect.setCustomAttributes"))) {
@@ -76,8 +82,10 @@ test_that("existsName works when XLConnect.setCustomAttributes is FALSE", {
   wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
   options(XLConnect.setCustomAttributes = FALSE)
+  # check without attributes (*.xls)
   expect_true(existsName(wb.xls, "AA_1"))
   expect_true(existsName(wb.xls, "BB_1"))
+  # check without attributes (*.xlsx)
   expect_true(existsName(wb.xlsx, "AA_1"))
   expect_true(existsName(wb.xlsx, "BB_1"))
   options(XLConnect.setCustomAttributes = TRUE)

--- a/tests/testthat/test.workbook.existsSheet.R
+++ b/tests/testthat/test.workbook.existsSheet.R
@@ -1,15 +1,24 @@
 test_that("test.workbook.existsSheet", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookExistsNameAndSheet.xlsx", create = FALSE)
+
+  # Check that the following sheets exists (*.xls)
   expect_true(existsSheet(wb.xls, "AAA"))
   expect_true(existsSheet(wb.xls, "BBB"))
   expect_true(existsSheet(wb.xls, "CCC"))
+
+  # Check that the following do NOT exists (*.xls)
   expect_false(existsSheet(wb.xls, "DDD"))
   expect_false(existsSheet(wb.xls, "'illegal name"))
   expect_false(existsSheet(wb.xls, "%&$$-^~@afk20 235-??a?"))
+
+  # Check that the following names exists (*.xlsx)
   expect_true(existsSheet(wb.xlsx, "AAA"))
   expect_true(existsSheet(wb.xlsx, "BBB"))
   expect_true(existsSheet(wb.xlsx, "CCC"))
+
+  # Check that the following do NOT exists (*.xlsx)
   expect_false(existsSheet(wb.xlsx, "DDD"))
   expect_false(existsSheet(wb.xlsx, "'illegal name"))
   expect_false(existsSheet(wb.xlsx, "%&$$-^~@afk20 235-??a?"))

--- a/tests/testthat/test.workbook.extraction.R
+++ b/tests/testthat/test.workbook.extraction.R
@@ -1,5 +1,6 @@
-test_that("extraction operator works for XLS worksheets", {
+test_that("workbook extraction & replacement operators work for XLS worksheets", {
   wb.xls <- loadWorkbook("resources/testWorkbookExtractionOperators.xls", create = TRUE)
+
   # Check that writing a data set to a worksheet works (*.xls)
   wb.xls["mtcars1"] <- mtcars
   expect_true("mtcars1" %in% getSheets(wb.xls))
@@ -12,8 +13,9 @@ test_that("extraction operator works for XLS worksheets", {
   expect_equal(c(31, 11), dim(wb.xls["mtcars2"]))
 })
 
-test_that("extraction operator works for XLSX worksheets", {
+test_that("workbook extraction & replacement operators work for XLSX worksheets", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookExtractionOperators.xlsx", create = TRUE)
+
   # Check that writing a data set to a worksheet works (*.xlsx)
   wb.xlsx["mtcars1"] <- mtcars
   expect_true("mtcars1" %in% getSheets(wb.xlsx))
@@ -26,8 +28,9 @@ test_that("extraction operator works for XLSX worksheets", {
   expect_equal(c(31, 11), dim(wb.xlsx["mtcars2"]))
 })
 
-test_that("extraction operator works for XLS named regions", {
+test_that("workbook extraction & replacement operators work for XLS named regions", {
   wb.xls <- loadWorkbook("resources/testWorkbookExtractionOperators.xls", create = TRUE)
+
   # Check that writing data to a named region works (*.xls)
   wb.xls[["mtcars3", "mtcars3!$B$7"]] <- mtcars
   expect_true("mtcars3" %in% getDefinedNames(wb.xls))
@@ -40,8 +43,9 @@ test_that("extraction operator works for XLS named regions", {
   expect_equal(c(32, 12), dim(wb.xls[["mtcars4"]]))
 })
 
-test_that("extraction operator works for XLSX named regions", {
+test_that("workbook extraction & replacement operators work for XLSX named regions", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookExtractionOperators.xlsx", create = TRUE)
+
   # Check that writing data to a named region works (*.xlsx)
   wb.xlsx[["mtcars3", "mtcars3!$B$7"]] <- mtcars
   expect_true("mtcars3" %in% getDefinedNames(wb.xlsx))

--- a/tests/testthat/test.workbook.extraction.R
+++ b/tests/testthat/test.workbook.extraction.R
@@ -1,47 +1,55 @@
 test_that("extraction operator works for XLS worksheets", {
   wb.xls <- loadWorkbook("resources/testWorkbookExtractionOperators.xls", create = TRUE)
+  # Check that writing a data set to a worksheet works (*.xls)
   wb.xls["mtcars1"] <- mtcars
   expect_true("mtcars1" %in% getSheets(wb.xls))
   expect_equal(33, as.vector(getLastRow(wb.xls, "mtcars1")))
   wb.xls["mtcars2", startRow = 6, startCol = 11, header = FALSE] <- mtcars
   expect_true("mtcars2" %in% getSheets(wb.xls))
   expect_equal(37, as.vector(getLastRow(wb.xls, "mtcars2")))
+  # Check that reading data from a worksheet works (*.xls)
   expect_equal(c(32, 11), dim(wb.xls["mtcars1"]))
   expect_equal(c(31, 11), dim(wb.xls["mtcars2"]))
 })
 
 test_that("extraction operator works for XLSX worksheets", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookExtractionOperators.xlsx", create = TRUE)
+  # Check that writing a data set to a worksheet works (*.xlsx)
   wb.xlsx["mtcars1"] <- mtcars
   expect_true("mtcars1" %in% getSheets(wb.xlsx))
   expect_equal(33, as.vector(getLastRow(wb.xlsx, "mtcars1")))
   wb.xlsx["mtcars2", startRow = 6, startCol = 11, header = FALSE] <- mtcars
   expect_true("mtcars2" %in% getSheets(wb.xlsx))
   expect_equal(37, as.vector(getLastRow(wb.xlsx, "mtcars2")))
+  # Check that reading data from a worksheet works (*.xlsx)
   expect_equal(c(32, 11), dim(wb.xlsx["mtcars1"]))
   expect_equal(c(31, 11), dim(wb.xlsx["mtcars2"]))
 })
 
 test_that("extraction operator works for XLS named regions", {
   wb.xls <- loadWorkbook("resources/testWorkbookExtractionOperators.xls", create = TRUE)
+  # Check that writing data to a named region works (*.xls)
   wb.xls[["mtcars3", "mtcars3!$B$7"]] <- mtcars
   expect_true("mtcars3" %in% getDefinedNames(wb.xls))
   expect_equal(39, as.vector(getLastRow(wb.xls, "mtcars3")))
   wb.xls[["mtcars4", "mtcars4!$D$8", rownames = "Car"]] <- mtcars
   expect_true("mtcars4" %in% getDefinedNames(wb.xls))
   expect_equal(40, as.vector(getLastRow(wb.xls, "mtcars4")))
+  # Check that reading data from a named region works (*.xls)
   expect_equal(c(32, 11), dim(wb.xls[["mtcars3"]]))
   expect_equal(c(32, 12), dim(wb.xls[["mtcars4"]]))
 })
 
 test_that("extraction operator works for XLSX named regions", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookExtractionOperators.xlsx", create = TRUE)
+  # Check that writing data to a named region works (*.xlsx)
   wb.xlsx[["mtcars3", "mtcars3!$B$7"]] <- mtcars
   expect_true("mtcars3" %in% getDefinedNames(wb.xlsx))
   expect_equal(39, as.vector(getLastRow(wb.xlsx, "mtcars3")))
   wb.xlsx[["mtcars4", "mtcars4!$D$8", rownames = "Car"]] <- mtcars
   expect_true("mtcars4" %in% getDefinedNames(wb.xlsx))
   expect_equal(40, as.vector(getLastRow(wb.xlsx, "mtcars4")))
+  # Check that reading data from a named region works (*.xlsx)
   expect_equal(c(32, 11), dim(wb.xlsx[["mtcars3"]]))
   expect_equal(c(32, 12), dim(wb.xlsx[["mtcars4"]]))
 })

--- a/tests/testthat/test.workbook.getActiveSheetIndex.R
+++ b/tests/testthat/test.workbook.getActiveSheetIndex.R
@@ -1,6 +1,11 @@
-test_that("test.workbook.getActiveSheetIndex", {
+test_that("Tests around querying the active sheet index of an Excel workbook", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookActiveSheetIndexAndName.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookActiveSheetIndexAndName.xlsx", create = FALSE)
+
+  # Check that the active sheet index is 5 (*.xls)
   expect_true(getActiveSheetIndex(wb.xls) == 5)
+
+  # Check that the active sheet index is 5 (*.xlsx)
   expect_true(getActiveSheetIndex(wb.xlsx) == 5)
 })

--- a/tests/testthat/test.workbook.getActiveSheetName.R
+++ b/tests/testthat/test.workbook.getActiveSheetName.R
@@ -1,6 +1,11 @@
 test_that("test.workbook.getActiveSheetName", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookActiveSheetIndexAndName.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookActiveSheetIndexAndName.xlsx", create = FALSE)
+
+  # Check that the active sheet name is 'Fifth Sheet' (*.xls)
   expect_true(getActiveSheetName(wb.xls) == "Fifth Sheet")
+
+  # Check that the active sheet name is 'Fifth Sheet' (*.xlsx)
   expect_true(getActiveSheetName(wb.xlsx) == "Fifth Sheet")
 })

--- a/tests/testthat/test.workbook.getBoundingBox.R
+++ b/tests/testthat/test.workbook.getBoundingBox.R
@@ -1,60 +1,60 @@
-test_that("getBoundingBox returns correct dimensions for a single sheet in XLS", {
+test_that("getBoundingBox returns correct dimensions when no row/column is specified (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
   dim1 <- matrix(c(17, 6, 25, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xls, sheet = "Test5")
   expect_equal(dim1, res)
 })
 
-test_that("getBoundingBox returns correct dimensions for a single sheet in XLSX", {
+test_that("getBoundingBox returns correct dimensions when no row/column is specified (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
   dim1 <- matrix(c(17, 6, 25, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xlsx, sheet = "Test5")
   expect_equal(dim1, res)
 })
 
-test_that("getBoundingBox returns correct dimensions for a specified region in XLS", {
+test_that("getBoundingBox returns correct dimensions when start and end cells are specified (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
   dim2 <- matrix(c(17, 7, 24, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xls, sheet = "Test5", startRow = 17, startCol = 7, endRow = 24, endCol = 9)
   expect_equal(dim2, res)
 })
 
-test_that("getBoundingBox returns correct dimensions for a specified region in XLSX", {
+test_that("getBoundingBox returns correct dimensions when start and end cells are specified (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
   dim2 <- matrix(c(17, 7, 24, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xlsx, sheet = "Test5", startRow = 17, startCol = 7, endRow = 24, endCol = 9)
   expect_equal(dim2, res)
 })
 
-test_that("getBoundingBox returns correct dimensions with start and end columns in XLS", {
+test_that("getBoundingBox returns correct dimensions when start and end columns are specified (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
   dim3 <- matrix(c(17, 7, 25, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xls, sheet = "Test5", startCol = 7, endCol = 9)
   expect_equal(dim3, res)
 })
 
-test_that("getBoundingBox returns correct dimensions with start and end columns in XLSX", {
+test_that("getBoundingBox returns correct dimensions when start and end columns are specified (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
   dim3 <- matrix(c(17, 7, 25, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xlsx, sheet = "Test5", startCol = 7, endCol = 9)
   expect_equal(dim3, res)
 })
 
-test_that("getBoundingBox returns correct dimensions with end row in XLS", {
+test_that("getBoundingBox returns correct dimensions when only the end row is specified (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
   dim4 <- matrix(c(17, 6, 24, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xls, sheet = "Test5", endRow = 24)
   expect_equal(dim4, res)
 })
 
-test_that("getBoundingBox returns correct dimensions with end row in XLSX", {
+test_that("getBoundingBox returns correct dimensions when only the end row is specified (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
   dim4 <- matrix(c(17, 6, 24, 9), dimnames = list(c(), c("Test5")))
   res <- getBoundingBox(wb.xlsx, sheet = "Test5", endRow = 24)
   expect_equal(dim4, res)
 })
 
-test_that("getBoundingBox returns correct dimensions for multiple sheets in XLS", {
+test_that("getBoundingBox returns correct dimensions when multiple sheets are specified (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookReadWorksheet.xls", create = FALSE)
   dim5 <- matrix(
     c(11, 6, 16, 9, 8, 4, 16, 7, 17, 6, 25, 9),
@@ -65,7 +65,7 @@ test_that("getBoundingBox returns correct dimensions for multiple sheets in XLS"
   expect_equal(dim5, res)
 })
 
-test_that("getBoundingBox returns correct dimensions for multiple sheets in XLSX", {
+test_that("getBoundingBox returns correct dimensions when multiple sheets are specified (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadWorksheet.xlsx", create = FALSE)
   dim5 <- matrix(
     c(11, 6, 16, 9, 8, 4, 16, 7, 17, 6, 25, 9),

--- a/tests/testthat/test.workbook.getDefinedNames.R
+++ b/tests/testthat/test.workbook.getDefinedNames.R
@@ -1,44 +1,58 @@
-test_that("getDefinedNames returns valid names only in XLS", {
+test_that("getDefinedNames returns valid names only - check that all and only the expected names exist (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookDefinedNames.xls", create = FALSE)
+
+  # Names defined in workbooks
   expectedNamesValidOnly <- c("FirstName", "SecondName", "FourthName", "FifthName")
   definedNames <- getDefinedNames(wb.xls, validOnly = TRUE)
   expect_true(setequal(expectedNamesValidOnly, definedNames))
 })
 
-test_that("getDefinedNames returns all names in XLS", {
+test_that("getDefinedNames returns all names - check that all and only the expected names exist (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookDefinedNames.xls", create = FALSE)
+
+  # Names defined in workbooks
   expectedNamesAll <- c("FirstName", "SecondName", "ThirdName", "FourthName", "FifthName")
   definedNames <- getDefinedNames(wb.xls, validOnly = FALSE)
   expect_true(setequal(expectedNamesAll, definedNames))
 })
 
-test_that("getDefinedNames returns valid names only in XLSX", {
+test_that("getDefinedNames returns valid names only - check that all and only the expected names exist (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookDefinedNames.xlsx", create = FALSE)
+
+  # Names defined in workbooks
   expectedNamesValidOnly <- c("FirstName", "SecondName", "FourthName", "FifthName")
   definedNames <- getDefinedNames(wb.xlsx, validOnly = TRUE)
   expect_true(setequal(expectedNamesValidOnly, definedNames))
 })
 
-test_that("getDefinedNames returns all names in XLSX", {
+test_that("getDefinedNames returns all names - check that all and only the expected names exist (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookDefinedNames.xlsx", create = FALSE)
+
+  # Names defined in workbooks
   expectedNamesAll <- c("FirstName", "SecondName", "ThirdName", "FourthName", "FifthName")
   definedNames <- getDefinedNames(wb.xlsx, validOnly = FALSE)
   expect_true(setequal(expectedNamesAll, definedNames))
 })
 
 test_that("getDefinedNames returns scoped names correctly in XLS", {
+  # scoped names
   wb.xls <- loadWorkbook("resources/testWorkbookGetDefinedNamesScoped.xls", create = FALSE)
+
   expectedNames <- c("ScopedName1", "ScopedName2")
   expectedScopes <- c("scoped_1", "scoped_2")
+
   res_xls <- getDefinedNames(wb.xls, validOnly = TRUE)
   expect_true(setequal(res_xls, expectedNames))
   expect_true(setequal(attributes(res_xls)$worksheetScope, expectedScopes))
 })
 
 test_that("getDefinedNames returns scoped names correctly in XLSX", {
+  # scoped names
   wb.xlsx <- loadWorkbook("resources/testWorkbookGetDefinedNamesScoped.xlsx", create = FALSE)
+
   expectedNames <- c("ScopedName1", "ScopedName2")
   expectedScopes <- c("scoped_1", "scoped_2")
+
   res_xlsx <- getDefinedNames(wb.xlsx, validOnly = TRUE)
   expect_true(setequal(res_xlsx, expectedNames))
   expect_true(setequal(attributes(res_xlsx)$worksheetScope, expectedScopes))

--- a/tests/testthat/test.workbook.getLastColumn.R
+++ b/tests/testthat/test.workbook.getLastColumn.R
@@ -1,14 +1,27 @@
 test_that("test.workbook.getLastColumn", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookGetLastRow.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookGetLastRow.xlsx", create = FALSE)
+
+  # Check if last column is determined correctly (*.xls)
   expect_equal(11, as.vector(getLastColumn(wb.xls, "mtcars")))
   expect_equal(15, as.vector(getLastColumn(wb.xls, "mtcars2")))
   expect_equal(19, as.vector(getLastColumn(wb.xls, "mtcars3")))
+
+  # Check if last column is determined correctly (*.xlsx)
   expect_equal(11, as.vector(getLastColumn(wb.xlsx, "mtcars")))
   expect_equal(15, as.vector(getLastColumn(wb.xlsx, "mtcars2")))
   expect_equal(19, as.vector(getLastColumn(wb.xlsx, "mtcars3")))
+
+  # Check that querying the last column of a non-existing worksheet throws an exception (*.xls)
   expect_error(getLastColumn(wb.xls, "doesNotExist"))
+
+  # Check that querying the last column of a non-existing worksheet throws an exception (*.xlsx)
   expect_error(getLastColumn(wb.xlsx, "doesNotExist"))
+
+  # Last column of an empty worksheet is 1 (.xls)
   expect_equal(c(empty = 1), getLastColumn(wb.xls, "empty"))
+
+  # Last column of an empty worksheet is 1 (.xlsx)
   expect_equal(c(empty = 1), getLastColumn(wb.xlsx, "empty"))
 })

--- a/tests/testthat/test.workbook.getLastRow.R
+++ b/tests/testthat/test.workbook.getLastRow.R
@@ -1,14 +1,27 @@
-test_that("test.workbook.getLastRow", {
+test_that("querying the last (non-empty) row of a worksheet", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookGetLastRow.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookGetLastRow.xlsx", create = FALSE)
+
+  # Check if last row is determined correctly (*.xls)
   expect_equal(33, as.vector(getLastRow(wb.xls, "mtcars")))
   expect_equal(41, as.vector(getLastRow(wb.xls, "mtcars2")))
   expect_equal(49, as.vector(getLastRow(wb.xls, "mtcars3")))
+
+  # Check if last row is determined correctly (*.xlsx)
   expect_equal(33, as.vector(getLastRow(wb.xlsx, "mtcars")))
   expect_equal(41, as.vector(getLastRow(wb.xlsx, "mtcars2")))
   expect_equal(49, as.vector(getLastRow(wb.xlsx, "mtcars3")))
+
+  # Check that querying the last row of a non-existing worksheet throws an exception (*.xls)
   expect_error(getLastRow(wb.xls, "doesNotExist"))
+
+  # Check that querying the last row of a non-existing worksheet throws an exception (*.xlsx)
   expect_error(getLastRow(wb.xlsx, "doesNotExist"))
+
+  # Last row of an empty worksheet is 1 (.xls)
   expect_equal(c(empty = 1), getLastRow(wb.xls, "empty"))
+
+  # Last row of an empty worksheet is 1 (.xlsx)
   expect_equal(c(empty = 1), getLastRow(wb.xlsx, "empty"))
 })

--- a/tests/testthat/test.workbook.getReferenceCoordinates.R
+++ b/tests/testthat/test.workbook.getReferenceCoordinates.R
@@ -1,4 +1,5 @@
 test_that("getReferenceCoordinatesForName returns correct coordinates for a valid name in XLS", {
+  # Check if reference formulas match (*.xls)
   wb.xls <- loadWorkbook("resources/testWorkbookReferenceFormula.xls", create = FALSE)
   expect_true(all(getReferenceCoordinatesForName(wb.xls, "FirstName") == matrix(c(1, 1, 1, 1), nrow = 2, byrow = TRUE)))
 })
@@ -9,6 +10,7 @@ test_that("getReferenceCoordinatesForName throws an error for a non-existent nam
 })
 
 test_that("getReferenceCoordinatesForName returns correct coordinates for a valid name in XLSX", {
+  # Check if reference positions match (*.xlsx)
   wb.xlsx <- loadWorkbook("resources/testWorkbookReferenceFormula.xlsx", create = FALSE)
   expect_true(all(
     getReferenceCoordinatesForName(wb.xlsx, "FirstName") == matrix(c(1, 1, 1, 1), nrow = 2, byrow = TRUE)

--- a/tests/testthat/test.workbook.getReferenceCoordinatesForTable.R
+++ b/tests/testthat/test.workbook.getReferenceCoordinatesForTable.R
@@ -1,5 +1,8 @@
 test_that("test.workbook.getReferenceCoordinatesForTable", {
+  # Create workbooks
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
+
+  # Check that querying the reference coordinates of an Excel table works as expected (*.xlsx)
   res <- getReferenceCoordinatesForTable(wb.xlsx, sheet = "Test", table = "TestTable1")
   expect_equal(matrix(c(5, 10, 4, 7), ncol = 2), res)
 })

--- a/tests/testthat/test.workbook.getReferenceFormula.R
+++ b/tests/testthat/test.workbook.getReferenceFormula.R
@@ -1,19 +1,30 @@
-test_that("test.workbook.getReferenceFormula", {
+test_that("Tests around querying Excel reference formulas", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookReferenceFormula.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookReferenceFormula.xlsx", create = FALSE)
+
+  # Check if reference formulas match (*.xls)
   expect_true(getReferenceFormula(wb.xls, "FirstName") == "Tabelle1!$A$1")
   expect_true(substring(getReferenceFormula(wb.xls, "SecondName"), 1, 5) == "#REF!")
+
+  # Check if reference formulas match (*.xlsx)
   expect_true(getReferenceFormula(wb.xlsx, "FirstName") == "Tabelle1!$A$1")
   expect_true(substring(getReferenceFormula(wb.xlsx, "SecondName"), 1, 5) == "#REF!")
+
+  # Check if reference formulas match and are in the global scope (*.xls)
   expect_formula <- "Tabelle1!$A$1"
   attributes(expect_formula) <- list(worksheetScope = "")
   expect_equal(expect_formula, getReferenceFormula(wb.xls, "FirstName"))
+
   expect_formula <- "#REF!"
   attributes(expect_formula) <- list(worksheetScope = "")
   expect_equal(expect_formula, substring(getReferenceFormula(wb.xls, "SecondName"), 1, 5))
+
+  # Check if reference formulas match and are in the global scope (*.xlsx)
   expect_formula <- "Tabelle1!$A$1"
   attributes(expect_formula) <- list(worksheetScope = "")
   expect_equal(expect_formula, getReferenceFormula(wb.xlsx, "FirstName"))
+
   expect_formula <- "#REF!"
   attributes(expect_formula) <- list(worksheetScope = "")
   expect_equal(expect_formula, substring(getReferenceFormula(wb.xlsx, "SecondName"), 1, 5))

--- a/tests/testthat/test.workbook.getSheetPos.R
+++ b/tests/testthat/test.workbook.getSheetPos.R
@@ -1,6 +1,7 @@
 test_that("getSheetPos returns correct positions for existing sheets in XLS", {
   wb.xls <- loadWorkbook("resources/testWorkbookGetSheetPos.xls", create = TRUE)
   createSheet(wb.xls, c("Sheet 1", "Sheet 2", "Sheet 3", "Sheet 4"))
+  # Check positions (*.xls)
   expected <- c(`Sheet 3` = 3, `Sheet 2` = 2, `Sheet 4` = 4, `Sheet 1` = 1)
   expect_equal(expected, getSheetPos(wb.xls, c("Sheet 3", "Sheet 2", "Sheet 4", "Sheet 1")))
 })
@@ -8,18 +9,21 @@ test_that("getSheetPos returns correct positions for existing sheets in XLS", {
 test_that("getSheetPos returns correct positions for existing sheets in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookGetSheetPos.xlsx", create = TRUE)
   createSheet(wb.xlsx, c("Sheet 1", "Sheet 2", "Sheet 3", "Sheet 4"))
+  # Check positions (*.xlsx)
   expected <- c(`Sheet 3` = 3, `Sheet 2` = 2, `Sheet 4` = 4, `Sheet 1` = 1)
   expect_equal(expected, getSheetPos(wb.xlsx, c("Sheet 3", "Sheet 2", "Sheet 4", "Sheet 1")))
 })
 
-test_that("getSheetPos handles non-existing and illegal sheet names in XLS", {
+test_that("getSheetPos returns 0 index for non-existing worksheets in XLS", {
   wb.xls <- loadWorkbook("resources/testWorkbookGetSheetPos.xls", create = TRUE)
+  # Check that querying a non-existing worksheet results in a 0 index (*.xls)
   expect_equal(c(NotExisting = 0), getSheetPos(wb.xls, "NotExisting"))
   expect_equal(0, as.vector(getSheetPos(wb.xls, "%#?%+?[-")))
 })
 
-test_that("getSheetPos handles non-existing and illegal sheet names in XLSX", {
+test_that("getSheetPos returns 0 index for non-existing worksheets in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookGetSheetPos.xlsx", create = TRUE)
+  # Check that querying a non-existing worksheet results in a 0 index (*.xlsx)
   expect_equal(c(NotExisting = 0), getSheetPos(wb.xlsx, "NotExisting"))
   expect_equal(0, as.vector(getSheetPos(wb.xlsx, "%#?%+?[-")))
 })

--- a/tests/testthat/test.workbook.getSheets.R
+++ b/tests/testthat/test.workbook.getSheets.R
@@ -1,11 +1,18 @@
-test_that("test.workbook.getSheets", {
+test_that("Tests around querying Excel worksheets", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookSheets.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookSheets.xlsx", create = FALSE)
+
+  # Sheets defined in workbooks
   expectedSheets <- c("A1", "B 2", "$$", "=", "@}", "11. Oct.", "\"quote\"", "+0")
+
+  # Check that all and only the expected sheets exist (*.xls)
   definedSheets <- getSheets(wb.xls)
   expect_true(
     length(setdiff(expectedSheets, definedSheets)) == 0 && length(setdiff(definedSheets, expectedSheets)) == 0
   )
+
+  # Check that all and only the expected sheets exist (*.xlsx)
   definedSheets <- getSheets(wb.xlsx)
   expect_true(
     length(setdiff(expectedSheets, definedSheets)) == 0 && length(setdiff(definedSheets, expectedSheets)) == 0

--- a/tests/testthat/test.workbook.getTables.R
+++ b/tests/testthat/test.workbook.getTables.R
@@ -1,22 +1,29 @@
-test_that("getTables returns a simplified list of tables", {
+test_that("querying Excel table works as expected (*.xlsx) with simplify = TRUE", {
+  # Create workbooks
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
+
+  # Check that querying Excel table works as expected (*.xlsx)
   res <- getTables(wb.xlsx, sheet = "Test", simplify = TRUE)
   expect_equal("TestTable1", res)
 })
 
-test_that("getTables returns a nested list of tables", {
+test_that("querying Excel table works as expected (*.xlsx) with simplify = FALSE", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
+
   res <- getTables(wb.xlsx, sheet = "Test", simplify = FALSE)
   expect_equal(list(Test = "TestTable1"), res)
 })
 
 test_that("getTables returns an empty list for a sheet with no tables", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
+
   res <- getTables(wb.xlsx, sheet = "NoTableHere", simplify = TRUE)
   expect_equal(character(0), res)
 })
 
-test_that("getTables throws an error for a non-existent sheet", {
+test_that("trying to query tables from a non-existent sheet throws an exception (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookReadTable.xlsx", create = FALSE)
+
+  # Check that trying to query tables from an non-existent sheet throws an exception (*.xlsx)
   expect_error(getTables(wb.xlsx, sheet = "DoesNotExist"))
 })

--- a/tests/testthat/test.workbook.hideSheet.R
+++ b/tests/testthat/test.workbook.hideSheet.R
@@ -1,4 +1,4 @@
-test_that("test.workbook.hideSheet", {
+test_that("Tests around hiding Excel worksheets", {
   wb.xls <- loadWorkbook("resources/testWorkbookHideSheet.xls", create = TRUE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookHideSheet.xlsx", create = TRUE)
   visibleSheet <- "VisibleSheet"
@@ -10,10 +10,14 @@ test_that("test.workbook.hideSheet", {
   createSheet(wb.xlsx, hiddenSheet)
   createSheet(wb.xls, veryHiddenSheet)
   createSheet(wb.xlsx, veryHiddenSheet)
+
+  # Check if sheets are hidden correspondingly (*.xls)
   hideSheet(wb.xls, hiddenSheet)
   expect_true(isSheetHidden(wb.xls, hiddenSheet))
   hideSheet(wb.xls, veryHiddenSheet, veryHidden = TRUE)
   expect_true(isSheetVeryHidden(wb.xls, veryHiddenSheet))
+
+  # Check if sheets are hidden correspondingly (*.xlsx)
   hideSheet(wb.xlsx, hiddenSheet)
   expect_true(isSheetHidden(wb.xlsx, hiddenSheet))
   hideSheet(wb.xlsx, veryHiddenSheet, veryHidden = TRUE)

--- a/tests/testthat/test.workbook.isSheetHidden.R
+++ b/tests/testthat/test.workbook.isSheetHidden.R
@@ -1,4 +1,5 @@
 test_that("isSheetHidden identifies hidden sheets correctly in XLS", {
+  # Check if sheets are hidden (*.xls)
   wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
   expect_true(isSheetHidden(wb.xls, 2))
   expect_true(isSheetHidden(wb.xls, "BBB"))
@@ -10,11 +11,13 @@ test_that("isSheetHidden identifies non-hidden sheets correctly in XLS", {
   expect_false(isSheetHidden(wb.xls, "AAA"))
   expect_false(isSheetHidden(wb.xls, 3))
   expect_false(isSheetHidden(wb.xls, "CCC"))
-  expect_false(isSheetHidden(wb.xls, 4))
-  expect_false(isSheetHidden(wb.xls, "DDD"))
+  expect_false(isSheetHidden(wb.xls, 4)) # Sheet is actually very hidden!
+  expect_false(isSheetHidden(wb.xls, "DDD")) # Sheet is actually very hidden!
 })
 
-test_that("isSheetHidden throws errors for invalid sheets in XLS", {
+test_that("isSheetHidden throws errors for invalid/non-existing sheets in XLS", {
+  # Check if quering invalid/non-existing sheets
+  # causes an exception (*.xls)
   wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
   expect_error(isSheetHidden(wb.xls, 200))
   expect_error(isSheetHidden(wb.xls, "Sheet does not exist"))
@@ -22,6 +25,7 @@ test_that("isSheetHidden throws errors for invalid sheets in XLS", {
 })
 
 test_that("isSheetHidden identifies hidden sheets correctly in XLSX", {
+  # Check if sheets are hidden (*.xlsx)
   wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
   expect_true(isSheetHidden(wb.xlsx, 2))
   expect_true(isSheetHidden(wb.xlsx, "BBB"))
@@ -33,11 +37,13 @@ test_that("isSheetHidden identifies non-hidden sheets correctly in XLSX", {
   expect_false(isSheetHidden(wb.xlsx, "AAA"))
   expect_false(isSheetHidden(wb.xlsx, 3))
   expect_false(isSheetHidden(wb.xlsx, "CCC"))
-  expect_false(isSheetHidden(wb.xlsx, 4))
-  expect_false(isSheetHidden(wb.xlsx, "DDD"))
+  expect_false(isSheetHidden(wb.xlsx, 4)) # Sheet is actually very hidden!
+  expect_false(isSheetHidden(wb.xlsx, "DDD")) # Sheet is actually very hidden!
 })
 
-test_that("isSheetHidden throws errors for invalid sheets in XLSX", {
+test_that("isSheetHidden throws errors for invalid/non-existing sheets in XLSX", {
+  # Check if quering invalid/non-existing sheets
+  # causes an exception (*.xlsx)
   wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
   expect_error(isSheetHidden(wb.xlsx, 200))
   expect_error(isSheetHidden(wb.xlsx, "Sheet does not exist"))

--- a/tests/testthat/test.workbook.isSheetVeryHidden.R
+++ b/tests/testthat/test.workbook.isSheetVeryHidden.R
@@ -8,13 +8,13 @@ test_that("isSheetVeryHidden identifies non-very hidden sheets correctly in XLS"
   wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
   expect_false(isSheetVeryHidden(wb.xls, 1))
   expect_false(isSheetVeryHidden(wb.xls, "AAA"))
-  expect_false(isSheetVeryHidden(wb.xls, 2))
-  expect_false(isSheetVeryHidden(wb.xls, "BBB"))
+  expect_false(isSheetVeryHidden(wb.xls, 2)) # Sheet is actually hidden only!
+  expect_false(isSheetVeryHidden(wb.xls, "BBB")) # Sheet is actually hidden only!
   expect_false(isSheetVeryHidden(wb.xls, 3))
   expect_false(isSheetVeryHidden(wb.xls, "CCC"))
 })
 
-test_that("isSheetVeryHidden throws errors for invalid sheets in XLS", {
+test_that("isSheetVeryHidden throws errors for invalid/non-existing sheets in XLS", {
   wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
   expect_error(isSheetVeryHidden(wb.xls, 200))
   expect_error(isSheetVeryHidden(wb.xls, "Sheet does not exist"))
@@ -31,13 +31,13 @@ test_that("isSheetVeryHidden identifies non-very hidden sheets correctly in XLSX
   wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
   expect_false(isSheetVeryHidden(wb.xlsx, 1))
   expect_false(isSheetVeryHidden(wb.xlsx, "AAA"))
-  expect_false(isSheetVeryHidden(wb.xlsx, 2))
-  expect_false(isSheetVeryHidden(wb.xlsx, "BBB"))
+  expect_false(isSheetVeryHidden(wb.xlsx, 2)) # Sheet is actually hidden only!
+  expect_false(isSheetVeryHidden(wb.xlsx, "BBB")) # Sheet is actually hidden only!
   expect_false(isSheetVeryHidden(wb.xlsx, 3))
   expect_false(isSheetVeryHidden(wb.xlsx, "CCC"))
 })
 
-test_that("isSheetVeryHidden throws errors for invalid sheets in XLSX", {
+test_that("isSheetVeryHidden throws errors for invalid/non-existing sheets in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
   expect_error(isSheetVeryHidden(wb.xlsx, 200))
   expect_error(isSheetVeryHidden(wb.xlsx, "Sheet does not exist"))

--- a/tests/testthat/test.workbook.isSheetVisible.R
+++ b/tests/testthat/test.workbook.isSheetVisible.R
@@ -1,6 +1,9 @@
-test_that("test.workbook.isSheetVisible", {
+test_that("checking the visibility of Excel worksheets", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookHiddenSheets.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookHiddenSheets.xlsx", create = FALSE)
+
+  # Check if sheets are visible (*.xls)
   expect_false(isSheetVisible(wb.xls, 2))
   expect_false(isSheetVisible(wb.xls, "BBB"))
   expect_true(isSheetVisible(wb.xls, 1))
@@ -9,6 +12,8 @@ test_that("test.workbook.isSheetVisible", {
   expect_true(isSheetVisible(wb.xls, "CCC"))
   expect_false(isSheetVisible(wb.xls, 4))
   expect_false(isSheetVisible(wb.xls, "DDD"))
+
+  # Check if sheets are visible (*.xlsx)
   expect_false(isSheetVisible(wb.xlsx, 2))
   expect_false(isSheetVisible(wb.xlsx, "BBB"))
   expect_true(isSheetVisible(wb.xlsx, 1))

--- a/tests/testthat/test.workbook.onErrorCell.R
+++ b/tests/testthat/test.workbook.onErrorCell.R
@@ -16,6 +16,8 @@ add_expected_attr <- function(df) {
 
 test_that("onErrorCell with XLC$ERROR.WARN works for xls", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookErrorCell.xls"), create = FALSE)
+
+  # Check that reading error cells with the warning flag set does not cause any issues (*.xls)
   onErrorCell(wb.xls, XLC$ERROR.WARN)
 
   # Test regions
@@ -31,9 +33,11 @@ test_that("onErrorCell with XLC$ERROR.WARN works for xls", {
     add_expected_attr(data.frame(B = c(4.3, NA, -2.5, 1.6, NA, 9.7), stringsAsFactors = FALSE)),
     "Error detected in cell"
   )
+  # Test with XLConnect.setCustomAttributes = FALSE
   withr::local_options(XLConnect.setCustomAttributes = FALSE)
   data_frame_without_worksheet_scope = data.frame(C = c(-53.2, NA, 34.1, -37.89, 0, 1.6), stringsAsFactors = FALSE)
   test_error_warn(wb.xls, "CC", data_frame_without_worksheet_scope, "Error detected in cell")
+  # Reset to TRUE for remaining tests
   withr::local_options(XLConnect.setCustomAttributes = TRUE)
   test_error_warn(
     wb.xls,
@@ -51,6 +55,8 @@ test_that("onErrorCell with XLC$ERROR.WARN works for xls", {
 
 test_that("onErrorCell with XLC$ERROR.WARN works for xlsx", {
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookErrorCell.xlsx"), create = FALSE)
+
+  # Check that reading error cells with the warning flag set does not cause any issues (*.xlsx)
   onErrorCell(wb.xlsx, XLC$ERROR.WARN)
 
   # Test regions
@@ -88,6 +94,8 @@ test_that("onErrorCell with XLC$ERROR.WARN works for xlsx", {
 
 test_that("onErrorCell with XLC$ERROR.STOP creates an error for xls", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookErrorCell.xls"), create = FALSE)
+
+  # Check that reading error cells with the stop flag set causes an exception (*.xls)
   onErrorCell(wb.xls, XLC$ERROR.STOP)
 
   expect_true(is(try(readNamedRegion(wb.xls, name = "AA")), "try-error"))
@@ -99,6 +107,8 @@ test_that("onErrorCell with XLC$ERROR.STOP creates an error for xls", {
 
 test_that("onErrorCell with XLC$ERROR.STOP creates an error for xlsx", {
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookErrorCell.xlsx"), create = FALSE)
+
+  # Check that reading error cells with the stop flag set causes an exception (*.xlsx)
   onErrorCell(wb.xlsx, XLC$ERROR.STOP)
 
   expect_true(is(try(readNamedRegion(wb.xlsx, name = "AA")), "try-error"))

--- a/tests/testthat/test.workbook.readNamedRegion.R
+++ b/tests/testthat/test.workbook.readNamedRegion.R
@@ -1,4 +1,5 @@
 test_that("test.workbook.readNamedRegion", {
+  # Create workbooks
   wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadNamedRegion.xls"), create = FALSE)
   wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadNamedRegion.xlsx"), create = FALSE)
   checkDf <- data.frame(
@@ -9,17 +10,33 @@ test_that("test.workbook.readNamedRegion", {
     stringsAsFactors = F
   )
   options(XLConnect.setCustomAttributes = FALSE)
+
+  # Check that the read named region equals the defined data.frame (*.xls)
   res <- readNamedRegion(wb.xls, "Test", header = TRUE)
   expect_equal(checkDf, res)
+
+  # Check that the read named region equals the defined data.frame (*.xlsx)
   res <- readNamedRegion(wb.xlsx, "Test", header = TRUE)
   expect_equal(checkDf, res)
+
+  # Check that the same works when explicitly specifying global scope (*.xls)
   res <- readNamedRegion(wb.xls, "Test", header = TRUE, worksheetScope = "")
   expect_equal(checkDf, res)
+
+  # Check that the same works when explicitly specifying global scope (*.xlsx)
   res <- readNamedRegion(wb.xlsx, "Test", header = TRUE, worksheetScope = "")
   expect_equal(checkDf, res)
+
+  # check that global ranges are not found when specifying a worksheet name (*.xls)
   expect_error(readNamedRegion(wb.xls, name = "Test", header = TRUE, worksheetScope = "Test"))
+
+  # check that global ranges are not found when specifying a worksheet name (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, name = "Test", header = TRUE, worksheetScope = "Test"))
+
+  # Check that attempting to read a non-existing named region throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "NameThatDoesNotExist"))
+
+  # Check that attempting to read a non-existing named region throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "NameThatDoesNotExist"))
   targetNoForce <- data.frame(
     AAA = c(NA, NA, NA, 780.9, NA),
@@ -35,6 +52,7 @@ test_that("test.workbook.readNamedRegion", {
     DDD = as.POSIXct(c("1984-01-11 12:00:00", "2012-02-06 16:15:23", "1984-01-11 12:00:00", NA, "1900-12-22 16:04:48")),
     stringsAsFactors = FALSE
   )
+  # Check that conversion performs ok (without forcing conversion; *.xls)
   res <- suppressWarnings(readNamedRegion(
     wb.xls,
     name = "Conversion",
@@ -44,6 +62,8 @@ test_that("test.workbook.readNamedRegion", {
     dateTimeFormat = "%d.%m.%Y %H:%M:%S"
   ))
   expect_equal(targetNoForce, res)
+
+  # Check that conversion performs ok (without forcing conversion; *.xlsx)
   res <- suppressWarnings(readNamedRegion(
     wb.xlsx,
     name = "Conversion",
@@ -53,6 +73,8 @@ test_that("test.workbook.readNamedRegion", {
     dateTimeFormat = "%d.%m.%Y %H:%M:%S"
   ))
   expect_equal(targetNoForce, res)
+
+  # Check that conversion performs ok (with forcing conversion; *.xls)
   res <- suppressWarnings(readNamedRegion(
     wb.xls,
     name = "Conversion",
@@ -62,6 +84,8 @@ test_that("test.workbook.readNamedRegion", {
     dateTimeFormat = "%d.%m.%Y %H:%M:%S"
   ))
   expect_equal(targetForce, res)
+
+  # Check that conversion performs ok (with forcing conversion; *.xlsx)
   res <- suppressWarnings(readNamedRegion(
     wb.xlsx,
     name = "Conversion",
@@ -75,8 +99,11 @@ test_that("test.workbook.readNamedRegion", {
     AAA = data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE),
     BBB = data.frame(D = 4:6, E = letters[4:6], F = c(FALSE, TRUE, TRUE), stringsAsFactors = FALSE)
   )
+  # Check that reading multiple named regions returns a named list (*.xls)
   res <- readNamedRegion(wb.xls, name = c("AAA", "BBB"), header = TRUE)
   expect_equal(target, res)
+
+  # Check that reading multiple named regions returns a named list (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("AAA", "BBB"), header = TRUE)
   expect_equal(target, res)
   target <- data.frame(
@@ -85,48 +112,90 @@ test_that("test.workbook.readNamedRegion", {
     check.names = FALSE,
     stringsAsFactors = FALSE
   )
+  # Check that reading named regions with check.names = FALSE works (*.xls)
   res <- readNamedRegion(wb.xls, name = "VariableNames", header = TRUE, check.names = FALSE)
   expect_equal(target, res)
+
+  # Check that reading named regions with check.names = FALSE works (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = "VariableNames", header = TRUE, check.names = FALSE)
   expect_equal(target, res)
+  # Check that attempting to specify both keep and drop throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "Conversion", header = TRUE, keep = c("AAA", "BBB"), drop = c("CCC", "DDD")))
+
+  # Check that attempting to specify both keep and drop throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "Conversion", header = TRUE, keep = c("AAA", "BBB"), drop = c("CCC", "DDD")))
+
+  # Check that attempting to keep a non-existing column (indicated by header name) throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "Conversion", header = TRUE, keep = c("AAA", "BBB", "ZZZ")))
+
+  # Check that attempting to keep a non-existing column (indicated by header name) throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "Conversion", header = TRUE, keep = c("AAA", "BBB", "ZZZ")))
+
+  # Check that attempting to keep a column (indicated by index) out of named region bounds throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "Conversion", header = TRUE, keep = c(1, 2, 5)))
+
+  # Check that attempting to keep a column (indicated by index) out of named region bounds throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "Conversion", header = TRUE, keep = c(1, 2, 5)))
+
+  # Check that attempting to drop a non-existing column (indicated by header name) throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "Conversion", header = TRUE, drop = c("AAA", "BBB", "ZZZ")))
+
+  # Check that attempting to drop a non-existing column (indicated by header name) throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "Conversion", header = TRUE, drop = c("AAA", "BBB", "ZZZ")))
+
+  # Check that attempting to drop a column (indicated by index) out of named region bounds throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "Conversion", header = TRUE, drop = c(1, 2, 5)))
+
+  # Check that attempting to drop a column (indicated by index) out of named region bounds throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "Conversion", header = TRUE, drop = c(1, 2, 5)))
   AAA <- data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE)
   BBB <- data.frame(D = 4:6, E = letters[4:6], F = c(FALSE, TRUE, TRUE), stringsAsFactors = FALSE)
+  # Check that keeping columns "NumericColumn" and "BooleanColumn" (= by name) with header=FALSE throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "Test", header = FALSE, keep = c("NumericColumn", "BooleanColumn")))
+
+  # Check that keeping columns "NumericColumn" and "BooleanColumn" (= by name) with header=FALSE throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "Test", header = FALSE, keep = c("NumericColumn", "BooleanColumn")))
+
+  # Check that dropping columns "StringColumn" and "DateTimeColumn" (= by name) with header=FALSE throws an exception (*.xls)
   expect_error(readNamedRegion(wb.xls, "Test", header = FALSE, drop = c("StringColumn", "DateTimeColumn")))
+
+  # Check that dropping columns "StringColumn" and "DateTimeColumn" (= by name) with header=FALSE throws an exception (*.xlsx)
   expect_error(readNamedRegion(wb.xlsx, "Test", header = FALSE, drop = c("StringColumn", "DateTimeColumn")))
+  # Keeping the same columns from multiple named regions (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB"), header = TRUE, keep = c(1, 3))
   expect_equal(list(Test = checkDf[, c(1, 3)], AAA = AAA[, c(1, 3)], BBB = BBB[, c(1, 3)]), res)
+
+  # Keeping the same columns from multiple named regions (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB"), header = TRUE, keep = c(1, 3))
   expect_equal(list(Test = checkDf[, c(1, 3)], AAA = AAA[, c(1, 3)], BBB = BBB[, c(1, 3)]), res)
+  # Testing the correct replication of the keep argument (reading from 3 named regions, while keep has length 2) (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB"), header = TRUE, keep = list(1, 3))
   expect_equal(list(Test = checkDf[1], AAA = AAA[3], BBB = BBB[1]), res)
+
+  # Testing the correct replication of the keep argument (reading from 3 named regions, while keep has length 2) (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB"), header = TRUE, keep = list(1, 3))
   expect_equal(list(Test = checkDf[1], AAA = AAA[3], BBB = BBB[1]), res)
+  # Keeping different columns from multiple named regions (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB"), header = TRUE, keep = list(c(1, 2), c(2, 3), c(1, 3)))
   expect_equal(list(Test = checkDf[, c(1, 2)], AAA = AAA[, c(2, 3)], BBB = BBB[, c(1, 3)]), res)
+
+  # Keeping different columns from multiple named regions (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB"), header = TRUE, keep = list(c(1, 2), c(2, 3), c(1, 3)))
   expect_equal(list(Test = checkDf[, c(1, 2)], AAA = AAA[, c(2, 3)], BBB = BBB[, c(1, 3)]), res)
+  # Keeping different columns from multiple named regions (2 keep list elements for 4 named regions) (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB", "Test"), header = TRUE, keep = list(c(1, 2), c(2, 3)))
   expect_equal(
     list(Test = checkDf[, c(1, 2)], AAA = AAA[, c(2, 3)], BBB = BBB[, c(1, 2)], Test = checkDf[, c(2, 3)]),
     res
   )
+
+  # Keeping different columns from multiple named regions (2 keep list elements for 4 named regions) (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB", "Test"), header = TRUE, keep = list(c(1, 2), c(2, 3)))
   expect_equal(
     list(Test = checkDf[, c(1, 2)], AAA = AAA[, c(2, 3)], BBB = BBB[, c(1, 2)], Test = checkDf[, c(2, 3)]),
     res
   )
+  # Dropping the same columns from multiple named regions (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB"), header = TRUE, drop = c(1, 2))
   expect_equal(
     list(
@@ -136,6 +205,8 @@ test_that("test.workbook.readNamedRegion", {
     ),
     res
   )
+
+  # Dropping the same columns from multiple named regions (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB"), header = TRUE, drop = c(1, 2))
   expect_equal(
     list(
@@ -145,10 +216,14 @@ test_that("test.workbook.readNamedRegion", {
     ),
     res
   )
+  # Testing the correct replication of the drop argument (reading from 3 named regions, while drop has length 2) (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB"), header = TRUE, drop = list(1, 2))
   expect_equal(list(Test = checkDf[, c(2, 3, 4)], AAA = AAA[, c(1, 3)], BBB = BBB[, c(2, 3)]), res)
+
+  # Testing the correct replication of the drop argument (reading from 3 named regions, while drop has length 2) (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB"), header = TRUE, drop = list(1, 2))
   expect_equal(list(Test = checkDf[, c(2, 3, 4)], AAA = AAA[, c(1, 3)], BBB = BBB[, c(2, 3)]), res)
+  # Dropping different columns from multiple named regions (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB"), header = TRUE, drop = list(c(1, 2), c(2, 3), c(1, 3)))
   expect_equal(
     list(
@@ -158,6 +233,8 @@ test_that("test.workbook.readNamedRegion", {
     ),
     res
   )
+
+  # Dropping different columns from multiple named regions (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB"), header = TRUE, drop = list(c(1, 2), c(2, 3), c(1, 3)))
   expect_equal(
     list(
@@ -167,6 +244,7 @@ test_that("test.workbook.readNamedRegion", {
     ),
     res
   )
+  # Dropping different columns from multiple named regions (2 drop list elements for 4 named regions) (*.xls)
   res <- readNamedRegion(wb.xls, name = c("Test", "AAA", "BBB", "Test"), header = TRUE, drop = list(c(1, 2), c(2, 3)))
   expect_equal(
     list(
@@ -177,6 +255,8 @@ test_that("test.workbook.readNamedRegion", {
     ),
     res
   )
+
+  # Dropping different columns from multiple named regions (2 drop list elements for 4 named regions) (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = c("Test", "AAA", "BBB", "Test"), header = TRUE, drop = list(c(1, 2), c(2, 3)))
   expect_equal(
     list(
@@ -192,6 +272,7 @@ test_that("test.workbook.readNamedRegion", {
     DDD = as.POSIXct(c("1984-01-11 12:00:00", NA, NA, NA, NA)),
     stringsAsFactors = FALSE
   )
+  # Check that conversion performs ok (without forcing conversion, keeping columns BBB and DDD; *.xls)
   res <- readNamedRegion(
     wb.xls,
     name = "Conversion",
@@ -202,6 +283,8 @@ test_that("test.workbook.readNamedRegion", {
     keep = c("BBB", "DDD")
   )
   expect_equal(targetNoForceSubset, res)
+
+  # Check that conversion performs ok (without forcing conversion, keeping columns BBB and DDD; *.xlsx)
   res <- readNamedRegion(
     wb.xlsx,
     name = "Conversion",
@@ -212,6 +295,7 @@ test_that("test.workbook.readNamedRegion", {
     keep = c("BBB", "DDD")
   )
   expect_equal(targetNoForceSubset, res)
+  # Check that conversion performs ok (without forcing conversion, dropping columns AAA and CCC; *.xls)
   res <- readNamedRegion(
     wb.xls,
     name = "Conversion",
@@ -222,6 +306,8 @@ test_that("test.workbook.readNamedRegion", {
     drop = c("AAA", "CCC")
   )
   expect_equal(targetNoForceSubset, res)
+
+  # Check that conversion performs ok (without forcing conversion, dropping columns AAA and CCC; *.xlsx)
   res <- readNamedRegion(
     wb.xlsx,
     name = "Conversion",
@@ -232,6 +318,7 @@ test_that("test.workbook.readNamedRegion", {
     drop = c("AAA", "CCC")
   )
   expect_equal(targetNoForceSubset, res)
+  # Check that conversion performs ok (without forcing conversion, keeping columns 2 and 4; *.xls)
   res <- readNamedRegion(
     wb.xls,
     name = "Conversion",
@@ -242,6 +329,8 @@ test_that("test.workbook.readNamedRegion", {
     keep = c(2, 4)
   )
   expect_equal(targetNoForceSubset, res)
+
+  # Check that conversion performs ok (without forcing conversion, keeping columns 2 and 4; *.xlsx)
   res <- readNamedRegion(
     wb.xlsx,
     name = "Conversion",
@@ -252,6 +341,7 @@ test_that("test.workbook.readNamedRegion", {
     keep = c(2, 4)
   )
   expect_equal(targetNoForceSubset, res)
+  # Check that conversion performs ok (without forcing conversion, dropping columns 1 and 3; *.xls)
   res <- suppressWarnings(readNamedRegion(
     wb.xls,
     name = "Conversion",
@@ -262,8 +352,10 @@ test_that("test.workbook.readNamedRegion", {
     drop = c(1, 3)
   ))
   expect_equal(targetNoForceSubset, res)
+
+  # Check that conversion performs ok (without forcing conversion, dropping columns 1 and 3; *.xlsx)
   res <- suppressWarnings(readNamedRegion(
-    wb.xls,
+    wb.xlsx,
     name = "Conversion",
     header = TRUE,
     colTypes = c(XLC$DATA_TYPE.NUMERIC, XLC$DATA_TYPE.STRING, XLC$DATA_TYPE.BOOLEAN, XLC$DATA_TYPE.DATETIME),
@@ -272,6 +364,7 @@ test_that("test.workbook.readNamedRegion", {
     drop = c(1, 3)
   ))
   expect_equal(targetNoForceSubset, res)
+  # Check that simplification works as expected (*.xls)
   res <- readNamedRegion(wb.xls, name = "Simplify1", header = TRUE, simplify = TRUE)
   expect_equal(1:10, res)
   res <- readNamedRegion(wb.xls, name = "Simplify2", header = TRUE, simplify = TRUE)
@@ -280,6 +373,8 @@ test_that("test.workbook.readNamedRegion", {
   expect_equal(c(TRUE, FALSE, FALSE, TRUE), res)
   res <- readNamedRegion(wb.xls, name = "Simplify4", header = TRUE, simplify = TRUE)
   expect_equal(c("one", "two", "three", "four", "five"), res)
+
+  # Check that simplification works as expected (*.xlsx)
   res <- readNamedRegion(wb.xlsx, name = "Simplify1", header = TRUE, simplify = TRUE)
   expect_equal(1:10, res)
   res <- readNamedRegion(wb.xlsx, name = "Simplify2", header = TRUE, simplify = TRUE)
@@ -288,19 +383,28 @@ test_that("test.workbook.readNamedRegion", {
   expect_equal(c(TRUE, FALSE, FALSE, TRUE), res)
   res <- readNamedRegion(wb.xlsx, name = "Simplify4", header = TRUE, simplify = TRUE)
   expect_equal(c("one", "two", "three", "four", "five"), res)
+  # Cached value tests: Create workbook
   wb.xls <- loadWorkbook(test_path("resources/testCachedValues.xls"), create = FALSE)
   wb.xlsx <- loadWorkbook(test_path("resources/testCachedValues.xlsx"), create = FALSE)
+  # "AllLocal" contains no formulae
   ref.xls.uncached <- readNamedRegion(wb.xls, "AllLocal", useCachedValues = FALSE)
   ref.xls.cached <- readNamedRegion(wb.xls, "AllLocal", useCachedValues = TRUE)
+  # cached and uncached results should be identical
   expect_equal(ref.xls.cached, ref.xls.uncached)
+
   ref.xlsx.uncached <- readNamedRegion(wb.xlsx, "AllLocal", useCachedValues = FALSE)
   ref.xlsx.cached <- readNamedRegion(wb.xlsx, "AllLocal", useCachedValues = TRUE)
   expect_equal(ref.xlsx.cached, ref.xlsx.uncached)
+
+  # XLS and XLSX results should be identical
   expect_equal(ref.xls.uncached, ref.xlsx.uncached)
+  # the other three named regions reference external worksheets and can't be read
+  # with useCachedValues=FALSE
   onErrorCell(wb.xls, XLC$ERROR.STOP)
   expect_error(readNamedRegion(wb.xls, "HeaderRemote", useCachedValues = FALSE))
   expect_error(readNamedRegion(wb.xls, "BodyRemote", useCachedValues = FALSE))
   expect_error(readNamedRegion(wb.xls, "AllRemote", useCachedValues = FALSE))
+
   onErrorCell(wb.xlsx, XLC$ERROR.STOP)
   expect_error(readNamedRegion(wb.xlsx, "HeaderRemote", useCachedValues = FALSE))
   expect_error(readNamedRegion(wb.xlsx, "BodyRemote", useCachedValues = FALSE))
@@ -317,10 +421,15 @@ test_that("test.workbook.readNamedRegion", {
   expect_equal(res, ref.xls.uncached)
   res <- readNamedRegion(wb.xlsx, "BothRemote", useCachedValues = TRUE)
   expect_equal(res, ref.xls.uncached)
+  # Check that dimensionality is not dropped when reading in a named region with rownames = x
+  # (see github issue #49)
   expected <- data.frame(B = 1:5, row.names = letters[1:5])
   res <- readNamedRegionFromFile(test_path("resources/testBug49.xlsx"), name = "test", rownames = "A")
   expect_equal(res, expected)
   options(XLConnect.setCustomAttributes = TRUE)
+
+  # Check that named region can be read within a worksheet scope (see github issue #37)
+
   name <- "Bla"
   wb37xlsx <- loadWorkbook(test_path("resources/test37.xlsx"), create = FALSE)
   read1 <- readNamedRegion(wb37xlsx, name, worksheetScope = "Sheet1")
@@ -332,5 +441,6 @@ test_that("test.workbook.readNamedRegion", {
   readBoth <- readNamedRegion(wb37xlsx, name, worksheetScope = c("Sheet1", "Sheet2"))
   expect_equal("bla1", colnames(readBoth[[1]]))
   expect_equal("bla2", colnames(readBoth[[2]]))
+
   expect_error(readNamedRegion(wb37xlsx, name, worksheetScope = "Sheet3"))
 })

--- a/tests/testthat/test.workbook.readTable.R
+++ b/tests/testthat/test.workbook.readTable.R
@@ -7,6 +7,8 @@ test_that("readTable reads a table from an XLSX file", {
     DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
     stringsAsFactors = F
   )
+
+  # Check that reading an Excel table works as expected (*.xlsx)
   res <- readTable(wb.xlsx, sheet = "Test", table = "TestTable1")
   expect_equal(checkDf, res)
 })

--- a/tests/testthat/test.workbook.readWorksheet.R
+++ b/tests/testthat/test.workbook.readWorksheet.R
@@ -7,6 +7,8 @@ test_that("reading basic worksheets by index and name works in XLS", {
     DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
     stringsAsFactors = FALSE
   )
+
+  # Read worksheet without specifying range - check that the read data region equals the defined data.frame
   expect_equal(common_checkDf, readWorksheet(wb.xls, 1), info = "XLS: Read sheet 1 by index")
   expect_equal(common_checkDf, readWorksheet(wb.xls, "Test1"), info = "XLS: Read sheet 'Test1' by name")
 })
@@ -20,6 +22,8 @@ test_that("reading basic worksheets by index and name works in XLSX", {
     DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
     stringsAsFactors = FALSE
   )
+
+  # Read worksheet without specifying range - check that the read data region equals the defined data.frame
   expect_equal(common_checkDf, readWorksheet(wb.xlsx, 1), info = "XLSX: Read sheet 1 by index")
   expect_equal(common_checkDf, readWorksheet(wb.xlsx, "Test1"), info = "XLSX: Read sheet 'Test1' by name")
 })
@@ -33,18 +37,24 @@ test_that("reading specific regions works in XLS", {
     DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
     stringsAsFactors = FALSE
   )
+
+  # Read worksheet by specifying a range - check that the read data region equals the defined data.frame
   expect_equal(
     common_checkDf,
     readWorksheet(wb.xls, 2, startRow = 17, startCol = 6, endRow = 22, endCol = 9, header = TRUE),
     info = "XLS: Specific area"
   )
+  # Test using a negative endRow/endCol
   expected_neg_end <- common_checkDf[-nrow(common_checkDf) + 0:1, -ncol(common_checkDf)]
   expect_equal(
     expected_neg_end,
     readWorksheet(wb.xls, "Test2", startRow = 17, startCol = 6, endRow = -2, endCol = -1, header = TRUE),
     info = "XLS: Negative endRow/Col"
   )
+
+  # Read worksheet by specifying a range via the region argument
   expect_equal(common_checkDf, readWorksheet(wb.xls, 2, region = "F17:I22", header = TRUE), info = "XLS: Region string")
+  # Read worksheet by specifying a range via the region argument (region takes precedence over index specifications)
   expect_equal(
     common_checkDf,
     readWorksheet(wb.xls, 2, region = "F17:I22", startRow = 88, endCol = 45, header = TRUE),
@@ -61,22 +71,28 @@ test_that("reading specific regions works in XLSX", {
     DateTimeColumn = as.POSIXct(c(NA, NA, "2010-09-09 21:03:07", "2010-09-10 21:03:07", "2010-09-11 21:03:07")),
     stringsAsFactors = FALSE
   )
+
+  # Read worksheet by specifying a range - check that the read data region equals the defined data.frame
   expect_equal(
     common_checkDf,
     readWorksheet(wb.xlsx, "Test2", startRow = 17, startCol = 6, endRow = 22, endCol = 9, header = TRUE),
     info = "XLSX: Specific area by name"
   )
+  # Test using a negative endRow/endCol
   expected_neg_end <- common_checkDf[-nrow(common_checkDf) + 0:1, -ncol(common_checkDf)]
   expect_equal(
     expected_neg_end,
     readWorksheet(wb.xlsx, "Test2", startRow = 17, startCol = 6, endRow = -2, endCol = -1, header = TRUE),
     info = "XLSX: Negative endRow/Col"
   )
+
+  # Read worksheet by specifying a range via the region argument
   expect_equal(
     common_checkDf,
     readWorksheet(wb.xlsx, "Test2", region = "F17:I22", header = TRUE),
     info = "XLSX: Region string by name"
   )
+  # Read worksheet by specifying a range via the region argument (region takes precedence over index specifications)
   expect_equal(
     common_checkDf,
     readWorksheet(wb.xlsx, "Test2", region = "F17:I22", startRow = 88, endCol = 45, header = TRUE),
@@ -120,8 +136,11 @@ test_that("reading sheets with NAs and varied data works in XLS", {
     D = c(NA, 1:5, NA, NA),
     stringsAsFactors = FALSE
   )
+
+  # Check that the data bounding box is correctly inferred even if there are blank cells in the last row
   expect_equal(common_checkDf1, readWorksheet(wb.xls, "Test4"), info = "XLS: Test4 sheet")
   expect_equal(common_checkDf2, readWorksheet(wb.xls, "Test5"), info = "XLS: Test5 sheet")
+  # Test with negative endRow/endCol
   expected_test4_neg <- common_checkDf1[-nrow(common_checkDf1) + 0:3, -ncol(common_checkDf1) + 0:1]
   expect_equal(
     expected_test4_neg,
@@ -152,8 +171,11 @@ test_that("reading sheets with NAs and varied data works in XLSX", {
     D = c(NA, 1:5, NA, NA),
     stringsAsFactors = FALSE
   )
+
+  # Check that the data bounding box is correctly inferred even if there are blank cells in the last row
   expect_equal(common_checkDf1, readWorksheet(wb.xlsx, "Test4"), info = "XLSX: Test4 sheet")
   expect_equal(common_checkDf2, readWorksheet(wb.xlsx, "Test5"), info = "XLSX: Test5 sheet")
+  # Test with negative endRow/endCol
   expected_test4_neg <- common_checkDf1[-nrow(common_checkDf1) + 0:3, -ncol(common_checkDf1) + 0:1]
   expect_equal(
     expected_test4_neg,
@@ -186,6 +208,8 @@ test_that("column type conversion works in XLS", {
     DDD = as.POSIXct(c("1984-01-11 12:00:00", "2012-02-06 16:15:23", "1984-01-11 12:00:00", NA, "1900-12-22 16:04:48")),
     stringsAsFactors = FALSE
   )
+
+  # Check that conversion performs ok (without forcing conversion)
   res_xls_noforce <- readWorksheet(
     wb.xls,
     sheet = "Conversion",
@@ -195,6 +219,8 @@ test_that("column type conversion works in XLS", {
     dateTimeFormat = datetime_fmt
   )
   expect_equal(targetNoForce, res_xls_noforce, info = "XLS: Conversion sheet, no force")
+
+  # Check that conversion performs ok (with forcing conversion)
   res_xls_force <- readWorksheet(
     wb.xls,
     sheet = "Conversion",
@@ -224,6 +250,8 @@ test_that("column type conversion works in XLSX", {
     DDD = as.POSIXct(c("1984-01-11 12:00:00", "2012-02-06 16:15:23", "1984-01-11 12:00:00", NA, "1900-12-22 16:04:48")),
     stringsAsFactors = FALSE
   )
+
+  # Check that conversion performs ok (without forcing conversion)
   res_xlsx_noforce <- readWorksheet(
     wb.xlsx,
     sheet = "Conversion",
@@ -233,6 +261,8 @@ test_that("column type conversion works in XLSX", {
     dateTimeFormat = datetime_fmt
   )
   expect_equal(targetNoForce, res_xlsx_noforce, info = "XLSX: Conversion sheet, no force")
+
+  # Check that conversion performs ok (with forcing conversion)
   res_xlsx_force <- readWorksheet(
     wb.xlsx,
     sheet = "Conversion",
@@ -250,6 +280,8 @@ test_that("reading multiple sheets by name works in XLS", {
     AAA = data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE),
     BBB = data.frame(D = 4:6, E = letters[4:6], F = c(FALSE, TRUE, TRUE), stringsAsFactors = FALSE)
   )
+
+  # Check that reading multiple worksheets (by name) returns a named list
   expect_equal(
     target_multi_sheet,
     readWorksheet(wb.xls, sheet = c("AAA", "BBB"), header = TRUE),
@@ -263,6 +295,8 @@ test_that("reading multiple sheets by name works in XLSX", {
     AAA = data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE),
     BBB = data.frame(D = 4:6, E = letters[4:6], F = c(FALSE, TRUE, TRUE), stringsAsFactors = FALSE)
   )
+
+  # Check that reading multiple worksheets (by name) returns a named list
   expect_equal(
     target_multi_sheet,
     readWorksheet(wb.xlsx, sheet = c("AAA", "BBB"), header = TRUE),
@@ -278,6 +312,8 @@ test_that("handling of variable names works in XLS", {
     check.names = FALSE,
     stringsAsFactors = FALSE
   )
+
+  # Check that reading worksheets with check.names = FALSE works
   res_xls_varnames <- readWorksheet(wb.xls, sheet = "VariableNames", header = TRUE, check.names = FALSE)
   expect_equal(target_var_names, res_xls_varnames, info = "XLS: VariableNames sheet, check.names=FALSE")
 })
@@ -290,6 +326,8 @@ test_that("handling of variable names works in XLSX", {
     check.names = FALSE,
     stringsAsFactors = FALSE
   )
+
+  # Check that reading worksheets with check.names = FALSE works
   res_xlsx_varnames <- readWorksheet(wb.xlsx, sheet = "VariableNames", header = TRUE, check.names = FALSE)
   expect_equal(target_var_names, res_xlsx_varnames, info = "XLSX: VariableNames sheet, check.names=FALSE")
 })
@@ -484,24 +522,32 @@ test_that("keep/drop with multiple sheets works in XLS", {
   )
   testAAA_df <- data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE)
   sheets_to_read <- c("Test1", "Test4", "Test5")
+
+  # Keeping the same columns from multiple sheets
   res_xls_kl1 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, keep = c(1, 2, 3))
   expect_equal(
     list(Test1 = common_checkDf[1:3], Test4 = common_checkDf1[1:3], Test5 = common_checkDf2[1:3]),
     res_xls_kl1,
     info = "XLS: Multi-sheet keep same cols"
   )
+
+  # Testing the correct replication of the keep argument (reading from 3 sheets, while keep has length 2)
   res_xls_kl2 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, keep = list(1, 2, c(1, 3)))
   expect_equal(
     list(Test1 = common_checkDf[1], Test4 = common_checkDf1[2], Test5 = common_checkDf2[c(1, 3)]),
     res_xls_kl2,
     info = "XLS: Multi-sheet keep different cols (simple list)"
   )
+
+  # Keeping different columns from multiple sheets
   res_xls_kl3 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, keep = list(c(1, 2), c(2, 3), c(1, 3)))
   expect_equal(
     list(Test1 = common_checkDf[1:2], Test4 = common_checkDf1[2:3], Test5 = common_checkDf2[c(1, 3)]),
     res_xls_kl3,
     info = "XLS: Multi-sheet keep different cols (list of vectors)"
   )
+
+  # Keeping different columns from multiple sheets (2 keep list elements for 4 sheets)
   sheets_plus_aaa <- c("Test1", "Test4", "Test5", "AAA")
   res_xls_kl4 <- readWorksheet(wb.xls, sheet = sheets_plus_aaa, header = TRUE, keep = list(c(1, 2), c(2, 3)))
   expect_equal(
@@ -514,12 +560,16 @@ test_that("keep/drop with multiple sheets works in XLS", {
     res_xls_kl4,
     info = "XLS: Multi-sheet keep, recycle last keep spec (adjusted for observed behavior)"
   )
+
+  # Dropping the same columns from multiple sheets
   res_xls_dl1 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, drop = c(1, 2))
   expect_equal(
     list(Test1 = common_checkDf[3:4], Test4 = common_checkDf1[3:4], Test5 = common_checkDf2[3:4]),
     res_xls_dl1,
     info = "XLS: Multi-sheet drop same cols"
   )
+
+  # Testing the correct replication of the drop argument (reading from 3 sheets, while drop has length 2)
   res_xls_dl2 <- readWorksheet(wb.xls, sheet = sheets_to_read, header = TRUE, drop = list(1, 2, c(1, 3)))
   expect_equal(
     list(Test1 = common_checkDf[2:4], Test4 = common_checkDf1[c(1, 3, 4)], Test5 = common_checkDf2[c(2, 4)]),
@@ -553,24 +603,32 @@ test_that("keep/drop with multiple sheets works in XLSX", {
   )
   testAAA_df <- data.frame(A = 1:3, B = letters[1:3], C = c(TRUE, TRUE, FALSE), stringsAsFactors = FALSE)
   sheets_to_read <- c("Test1", "Test4", "Test5")
+
+  # Keeping the same columns from multiple sheets
   res_xlsx_kl1 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, keep = c(1, 2, 3))
   expect_equal(
     list(Test1 = common_checkDf[1:3], Test4 = common_checkDf1[1:3], Test5 = common_checkDf2[1:3]),
     res_xlsx_kl1,
     info = "XLSX: Multi-sheet keep same cols"
   )
+
+  # Testing the correct replication of the keep argument (reading from 3 sheets, while keep has length 2)
   res_xlsx_kl2 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, keep = list(1, 2, c(1, 3)))
   expect_equal(
     list(Test1 = common_checkDf[1], Test4 = common_checkDf1[2], Test5 = common_checkDf2[c(1, 3)]),
     res_xlsx_kl2,
     info = "XLSX: Multi-sheet keep different cols (simple list)"
   )
+
+  # Keeping different columns from multiple sheets
   res_xlsx_kl3 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, keep = list(c(1, 2), c(2, 3), c(1, 3)))
   expect_equal(
     list(Test1 = common_checkDf[1:2], Test4 = common_checkDf1[2:3], Test5 = common_checkDf2[c(1, 3)]),
     res_xlsx_kl3,
     info = "XLSX: Multi-sheet keep different cols (list of vectors)"
   )
+
+  # Keeping different columns from multiple sheets (2 keep list elements for 4 sheets)
   sheets_plus_aaa <- c("Test1", "Test4", "Test5", "AAA")
   res_xlsx_kl4 <- readWorksheet(wb.xlsx, sheet = sheets_plus_aaa, header = TRUE, keep = list(c(1, 2), c(2, 3)))
   expect_equal(
@@ -583,12 +641,16 @@ test_that("keep/drop with multiple sheets works in XLSX", {
     res_xlsx_kl4,
     info = "XLSX: Multi-sheet keep, recycle last keep spec (adjusted for observed behavior)"
   )
+
+  # Dropping the same columns from multiple sheets
   res_xlsx_dl1 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, drop = c(1, 2))
   expect_equal(
     list(Test1 = common_checkDf[3:4], Test4 = common_checkDf1[3:4], Test5 = common_checkDf2[3:4]),
     res_xlsx_dl1,
     info = "XLSX: Multi-sheet drop same cols"
   )
+
+  # Testing the correct replication of the drop argument (reading from 3 sheets, while drop has length 2)
   res_xlsx_dl2 <- readWorksheet(wb.xlsx, sheet = sheets_to_read, header = TRUE, drop = list(1, 2, c(1, 3)))
   expect_equal(
     list(Test1 = common_checkDf[2:4], Test4 = common_checkDf1[c(1, 3, 4)], Test5 = common_checkDf2[c(2, 4)]),
@@ -599,6 +661,8 @@ test_that("keep/drop with multiple sheets works in XLSX", {
 
 test_that("autofitRow and autofitCol work for BoundingBox sheet in XLS", {
   wb.xls <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xls"), create = FALSE)
+
+  # Checking bounding-box resolution
   target1_bb <- data.frame(
     Col1 = c(NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 7, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA),
     Col2 = c(NA, NA, NA, 3, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 13),
@@ -1038,6 +1102,8 @@ test_that("autofitRow and autofitCol work for BoundingBox sheet in XLS", {
 
 test_that("autofitRow and autofitCol for BoundingBox sheet work in XLSX", {
   wb.xlsx <- loadWorkbook(test_path("resources/testWorkbookReadWorksheet.xlsx"), create = FALSE)
+
+  # Checking bounding-box resolution
   target1_bb <- data.frame(
     Col1 = c(NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 7, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA),
     Col2 = c(NA, NA, NA, 3, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 13),
@@ -1477,9 +1543,13 @@ test_that("autofitRow and autofitCol for BoundingBox sheet work in XLSX", {
 
 test_that("useCachedValues and onErrorCell interaction works in XLS", {
   wb.xls.cache <- loadWorkbook(test_path("resources/testCachedValues.xls"), create = FALSE)
+
+  # "AllLocal" contains no formulae - cached and uncached results should be identical
   ref.xls.uncached <- readWorksheet(wb.xls.cache, "AllLocal", useCachedValues = FALSE)
   ref.xls.cached <- readWorksheet(wb.xls.cache, "AllLocal", useCachedValues = TRUE)
   expect_equal(ref.xls.cached, ref.xls.uncached, info = "XLS: Cached vs Uncached for AllLocal")
+
+  # The other three named regions reference external worksheets and can't be read with useCachedValues=FALSE
   onErrorCell(wb.xls.cache, XLC$ERROR.STOP)
   expect_error(
     readWorksheet(wb.xls.cache, "HeaderRemote", useCachedValues = FALSE),
@@ -1493,6 +1563,7 @@ test_that("useCachedValues and onErrorCell interaction works in XLS", {
     readWorksheet(wb.xls.cache, "AllRemote", useCachedValues = FALSE),
     info = "XLS: AllRemote uncached error"
   )
+
   expect_equal(
     readWorksheet(wb.xls.cache, "HeadersRemote", useCachedValues = TRUE),
     ref.xls.uncached,
@@ -1512,9 +1583,13 @@ test_that("useCachedValues and onErrorCell interaction works in XLS", {
 
 test_that("useCachedValues and onErrorCell interaction works in XLSX", {
   wb.xlsx.cache <- loadWorkbook(test_path("resources/testCachedValues.xlsx"), create = FALSE)
+
+  # "AllLocal" contains no formulae - cached and uncached results should be identical
   ref.xlsx.uncached <- readWorksheet(wb.xlsx.cache, "AllLocal", useCachedValues = FALSE)
   ref.xlsx.cached <- readWorksheet(wb.xlsx.cache, "AllLocal", useCachedValues = TRUE)
   expect_equal(ref.xlsx.cached, ref.xlsx.uncached, info = "XLSX: Cached vs Uncached for AllLocal")
+
+  # The other three named regions reference external worksheets and can't be read with useCachedValues=FALSE
   onErrorCell(wb.xlsx.cache, XLC$ERROR.STOP)
   expect_error(
     readWorksheet(wb.xlsx.cache, "HeaderRemote", useCachedValues = FALSE),
@@ -1528,6 +1603,7 @@ test_that("useCachedValues and onErrorCell interaction works in XLSX", {
     readWorksheet(wb.xlsx.cache, "AllRemote", useCachedValues = FALSE),
     info = "XLSX: AllRemote uncached error"
   )
+
   expect_equal(
     readWorksheet(wb.xlsx.cache, "HeadersRemote", useCachedValues = TRUE),
     ref.xlsx.uncached,
@@ -1546,6 +1622,8 @@ test_that("useCachedValues and onErrorCell interaction works in XLSX", {
 })
 
 test_that("readWorksheetFromFile with useCachedValues works (Bug 52)", {
+  # Check that reading cached cell values in conjunction with converting cell values to string
+  # does not lead to cell formulas being returned (see github issue #52)
   res_bug52 <- readWorksheetFromFile(test_path("resources/testBug52.xlsx"), sheet = 1, useCachedValues = TRUE)
   expected_bug52 <- data.frame(
     Var1 = c(2, 4, 6),
@@ -1558,12 +1636,16 @@ test_that("readWorksheetFromFile with useCachedValues works (Bug 52)", {
 })
 
 test_that("readWorksheetFromFile with rownames works (Bug 49)", {
+  # Check that dimensionality is not dropped when reading in a worksheet with rownames = x
+  # (see github issue #49)
   expected_bug49 <- data.frame(B = 1:5, row.names = letters[1:5])
   res_bug49 <- readWorksheetFromFile(test_path("resources/testBug49.xlsx"), sheet = 1, rownames = 1)
   expect_equal(res_bug49, expected_bug49, info = "Bug 49 (rownames)")
 })
 
 test_that("readWorksheetFromFile with dateTimeFormat and forceConversion works (Bug 53)", {
+  # Check that dates are correctly converted to string in 1904-windowing based Excel files
+  # (see github issue #53)
   expected_bug53_sheet1 <- data.frame(A = c("2003-04-06", "2014-10-30", "abc"), stringsAsFactors = FALSE)
   res_bug53_sheet1 <- readWorksheetFromFile(
     test_path("resources/testBug53.xlsx"),
@@ -1571,6 +1653,8 @@ test_that("readWorksheetFromFile with dateTimeFormat and forceConversion works (
     dateTimeFormat = "%Y-%m-%d"
   )
   expect_equal(res_bug53_sheet1, expected_bug53_sheet1, info = "Bug 53 (sheet 1, dateTimeFormat)")
+
+  # Check that numbers are correctly converted to string 1904-windowing based Excel files
   expected_bug53_sheet2 <- data.frame(A = as.POSIXct(c("2015-12-01", "2015-11-17", "1984-01-11")))
   res_bug53_sheet2 <- readWorksheetFromFile(
     test_path("resources/testBug53.xlsx"),
@@ -1582,6 +1666,7 @@ test_that("readWorksheetFromFile with dateTimeFormat and forceConversion works (
 })
 
 test_that("reading sparse bitset worksheet works", {
+  # Cover use of SparseBitSet in POI 4.1.2 (GH #131)
   wbSparse.xlsx <- loadWorkbook(test_path("resources/testReadWorksheetSparseBitSet.xlsx"), create = FALSE)
   expect_silent(sparseSheet <- readWorksheet(wbSparse.xlsx, "hist"))
   expect_true(is.data.frame(sparseSheet))

--- a/tests/testthat/test.workbook.removeName.R
+++ b/tests/testthat/test.workbook.removeName.R
@@ -1,21 +1,21 @@
-test_that("removeName removes an existing name in XLS", {
+test_that("when removing a name from a worksheet it does not exist anymore (*.xls) - assumes 'existsName' is working correctly", {
   wb.xls <- loadWorkbook("resources/testWorkbookRemoveName.xls", create = FALSE)
   removeName(wb.xls, "AA")
   expect_false(existsName(wb.xls, "AA"))
 })
 
-test_that("removeName removes an existing name in XLSX", {
+test_that("when removing a name from a worksheet it does not exist anymore (*.xlsx) - assumes 'existsName' is working correctly", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveName.xlsx", create = FALSE)
   removeName(wb.xlsx, "AA")
   expect_false(existsName(wb.xlsx, "AA"))
 })
 
-test_that("removeName does not throw an error for a non-existent name in XLS", {
+test_that("attempting to remove a non-existing name does not throw an exception (*.xls)", {
   wb.xls <- loadWorkbook("resources/testWorkbookRemoveName.xls", create = FALSE)
   expect_error(removeName(wb.xls, "NameWhichDoesNotExist"), NA)
 })
 
-test_that("removeName does not throw an error for a non-existent name in XLSX", {
+test_that("attempting to remove a non-existing name does not throw an exception (*.xlsx)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveName.xlsx", create = FALSE)
   expect_error(removeName(wb.xlsx, "NameWhichDoesNotExist"), NA)
 })

--- a/tests/testthat/test.workbook.removeSheet.R
+++ b/tests/testthat/test.workbook.removeSheet.R
@@ -1,23 +1,27 @@
-test_that("removeSheet removes an existing sheet in XLS", {
+test_that("removeSheet removes an existing sheet in XLS - assumes 'existsSheet' to be working properly", {
   wb.xls <- loadWorkbook("resources/testWorkbookRemoveSheet.xls", create = FALSE)
+  # Check that removing a sheet works fine (*.xls)
   removeSheet(wb.xls, "BBB")
   expect_false(existsSheet(wb.xls, "BBB"))
 })
 
-test_that("removeSheet removes an existing sheet in XLSX", {
+test_that("removeSheet removes an existing sheet in XLSX - assumes 'existsSheet' to be working properly", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveSheet.xlsx", create = FALSE)
+  # Check that removing a sheet works fine (*.xlsx)
   removeSheet(wb.xlsx, "BBB")
   expect_false(existsSheet(wb.xlsx, "BBB"))
 })
 
-test_that("removeSheet does not throw an error for a non-existent sheet in XLS", {
+test_that("removeSheet does not throw an exception when removing a non-existing sheet in XLS", {
   wb.xls <- loadWorkbook("resources/testWorkbookRemoveSheet.xls", create = FALSE)
+  # Check that removing a non-existing sheet does not throw an exception (*.xls)
   expect_error(removeSheet(wb.xls, 35), NA)
   expect_error(removeSheet(wb.xls, "SheetWhichDoesNotExist"), NA)
 })
 
-test_that("removeSheet does not throw an error for a non-existent sheet in XLSX", {
+test_that("removeSheet does not throw an exception when removing a non-existing sheet in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookRemoveSheet.xlsx", create = FALSE)
+  # Check that removing a non-existing sheet does not throw an exception (*.xlsx)
   expect_error(removeSheet(wb.xlsx, 35), NA)
   expect_error(removeSheet(wb.xlsx, "SheetWhichDoesNotExist"), NA)
 })

--- a/tests/testthat/test.workbook.renameSheet.R
+++ b/tests/testthat/test.workbook.renameSheet.R
@@ -1,26 +1,47 @@
 test_that("test.workbook.renameSheet", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookRenameSheet.xls", create = TRUE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookRenameSheet.xlsx", create = TRUE)
+
+  # Check that renaming a sheet (using its name) works fine (*.xls)
+  # (assumes 'createSheet' and 'existsSheet' to be working properly)
   createSheet(wb.xls, name = "OldName1")
   renameSheet(wb.xls, sheet = "OldName1", newName = "NewName1")
   expect_true(existsSheet(wb.xls, "NewName1"))
   expect_false(existsSheet(wb.xls, "OldName1"))
+
+  # Check that renaming a sheet (using its name) works fine (*.xlsx)
+  # (assumes 'createSheet' and 'existsSheet' to be working properly)
   createSheet(wb.xlsx, name = "OldName1")
   renameSheet(wb.xlsx, sheet = "OldName1", newName = "NewName1")
   expect_true(existsSheet(wb.xlsx, "NewName1"))
   expect_false(existsSheet(wb.xlsx, "OldName1"))
+
+  # Check that renaming a sheet (using its index) works fine (*.xls)
+  # (assumes 'createSheet' and 'existsSheet' to be working properly)
   createSheet(wb.xls, name = "OldName2")
   renameSheet(wb.xls, sheet = 2, newName = "NewName2")
   expect_true(existsSheet(wb.xls, "NewName2"))
   expect_false(existsSheet(wb.xls, "OldName2"))
+
+  # Check that renaming a sheet (using its index) works fine (*.xlsx)
+  # (assumes 'createSheet' and 'existsSheet' to be working properly)
   createSheet(wb.xlsx, name = "OldName2")
   renameSheet(wb.xlsx, sheet = 2, newName = "NewName2")
   expect_true(existsSheet(wb.xlsx, "NewName2"))
   expect_false(existsSheet(wb.xlsx, "OldName2"))
+
+  # Check that renaming a non-existing sheet throws an exception (*.xls)
   expect_error(renameSheet(wb.xls, sheet = "NonExisting", newName = "ShouldStillNotExist"), "IllegalArgumentException")
+
+  # Check that renaming a non-existing sheet throws an exception (*.xlsx)
   expect_error(renameSheet(wb.xlsx, sheet = "NonExisting", newName = "ShouldStillNotExist"), "IllegalArgumentException")
+
+  # Check that renaming a sheet with an invalid new name throws an exception (*.xls)
   createSheet(wb.xls, name = "SomeName")
   expect_error(renameSheet(wb.xls, sheet = "SomeName", newName = "'invalid"), "IllegalArgumentException")
+
+  # Check that renaming a sheet with an invalid new name throws an exception (*.xlsx)
   createSheet(wb.xlsx, name = "SomeName")
   expect_error(renameSheet(wb.xlsx, sheet = "SomeName", newName = "'invalid"), "IllegalArgumentException")
 })

--- a/tests/testthat/test.workbook.saveWorkbook.R
+++ b/tests/testthat/test.workbook.saveWorkbook.R
@@ -1,20 +1,32 @@
 test_that("saveWorkbook saves an XLS file", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+  # Create workbooks
   file.xls <- withr::local_tempfile(fileext = ".xls")
 
   wb.xls <- loadWorkbook(file.xls, create = TRUE)
+
+  # Files don't exist yet
   expect_false(file.exists(file.xls))
+
   saveWorkbook(wb.xls)
+
+  # Check that file exists after saving (*.xls)
   expect_true(file.exists(file.xls))
 })
 
 test_that("saveWorkbook saves an XLSX file", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
+  # Create workbooks
   file.xlsx <- withr::local_tempfile(fileext = ".xlsx")
 
   wb.xlsx <- loadWorkbook(file.xlsx, create = TRUE)
+
+  # Files don't exist yet
   expect_false(file.exists(file.xlsx))
+
   saveWorkbook(wb.xlsx)
+
+  # Check that file exists after saving (*.xlsx)
   expect_true(file.exists(file.xlsx))
 })
 
@@ -24,6 +36,8 @@ test_that("saveWorkbook saves an XLS file to a new location", {
   newFile.xls <- withr::local_tempfile(fileext = ".xls")
 
   wb.xls <- loadWorkbook(file.xls, create = TRUE)
+
+  # Check save as (*.xls)
   saveWorkbook(wb.xls, file = newFile.xls)
   expect_true(file.exists(newFile.xls))
 })
@@ -34,6 +48,8 @@ test_that("saveWorkbook saves an XLSX file to a new location", {
   newFile.xlsx <- withr::local_tempfile(fileext = ".xlsx")
 
   wb.xlsx <- loadWorkbook(file.xlsx, create = TRUE)
+
+  # Check save as (*.xlsx)
   saveWorkbook(wb.xlsx, file = newFile.xlsx)
   expect_true(file.exists(newFile.xlsx))
 })

--- a/tests/testthat/test.workbook.setActiveSheet.R
+++ b/tests/testthat/test.workbook.setActiveSheet.R
@@ -1,20 +1,31 @@
 test_that("test.workbook.setActiveSheet", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookSetActiveSheet.xls", create = FALSE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookSetActiveSheet.xlsx", create = FALSE)
+
+  # Check that setting the active sheet works ok (*.xls)
+  # (assumes that 'getActiveSheetIndex' works fine)
   setActiveSheet(wb.xls, 1)
   expect_true(getActiveSheetIndex(wb.xls) == 1)
   setActiveSheet(wb.xls, 3)
   expect_true(getActiveSheetIndex(wb.xls) == 3)
   setActiveSheet(wb.xls, "Sheet2")
   expect_true(getActiveSheetIndex(wb.xls) == 2)
+
+  # Check that setting the active sheet works ok (*.xlsx)
+  # (assumes that 'getActiveSheetIndex' works fine)
   setActiveSheet(wb.xlsx, 1)
   expect_true(getActiveSheetIndex(wb.xlsx) == 1)
   setActiveSheet(wb.xlsx, 3)
   expect_true(getActiveSheetIndex(wb.xlsx) == 3)
   setActiveSheet(wb.xlsx, "Sheet2")
   expect_true(getActiveSheetIndex(wb.xlsx) == 2)
+
+  # Check that setting an illegal active sheet throws an exception (*.xls)
   expect_error(setActiveSheet(wb.xls, 19), "IllegalArgumentException")
   expect_error(setActiveSheet(wb.xls, "SheetWhichDoesNotExist"), "IllegalArgumentException")
+
+  # Check that setting an illegal active sheet throws an exception (*.xlsx)
   expect_error(setActiveSheet(wb.xlsx, 19), "IllegalArgumentException")
   expect_error(setActiveSheet(wb.xlsx, "SheetWhichDoesNotExist"), "IllegalArgumentException")
 })

--- a/tests/testthat/test.workbook.setForceFormulaRecalculation.R
+++ b/tests/testthat/test.workbook.setForceFormulaRecalculation.R
@@ -1,11 +1,19 @@
-test_that("test.workbook.setForceFormulaRecalculation", {
+test_that("workbook.setForceFormulaRecalculation - setting and getting force formula recalculation flags", {
+  # Create workbook
   wb.xlsx <- loadWorkbook("resources/testBug170.xlsx", create = FALSE)
+
+  # Check that setting the force formula recalculation flag works fine (*.xlsx)
+  # (assumes that 'getForceFormulaRecalculation' works fine)
   setForceFormulaRecalculation(wb.xlsx, 1, TRUE)
   expect_true(getForceFormulaRecalculation(wb.xlsx, 1))
   setForceFormulaRecalculation(wb.xlsx, c("Sheet1", "Sheet2"), FALSE)
   expect_false(getForceFormulaRecalculation(wb.xlsx, "Sheet2"))
+
+  # Check that passing multiple sheets doesn't cause problems
   setForceFormulaRecalculation(wb.xlsx, "*", TRUE)
   expect_true(all(getForceFormulaRecalculation(wb.xlsx, "*")))
+
+  # Check that setting the force formula recalculation flag an illegal active sheet throws an exception (*.xlsx)
   expect_error(setForceFormulaRecalculation(wb.xlsx, 12, TRUE), "IllegalArgumentException")
   expect_error(setForceFormulaRecalculation(wb.xlsx, "SheetWhichDoesNotExist", TRUE), "IllegalArgumentException")
 })

--- a/tests/testthat/test.workbook.setMissingValue.R
+++ b/tests/testthat/test.workbook.setMissingValue.R
@@ -1,10 +1,12 @@
-test_that("setMissingValue works correctly for a single value in XLS", {
+test_that("writing and reading data with default missing value behaviour returns original data (XLS)", {
   wb.xls <- loadWorkbook("resources/testWorkbookSetMissingValue.xls", create = TRUE)
   data <- data.frame(A = c(4.2, -3.2, NA, 1.34), B = c("A", NA, "C", "D"), stringsAsFactors = FALSE)
   name <- "missing"
   createSheet(wb.xls, name = name)
   createName(wb.xls, name = name, formula = paste(name, "$A$1", sep = "!"))
 
+  # Check that writing and reading the data with the default missing value behaviour returns
+  # the original data (*.xls)
   writeNamedRegion(wb.xls, data, name = name)
   res <- readNamedRegion(wb.xls, name = name)
   attr(data, "worksheetScope") <- ""
@@ -16,20 +18,26 @@ test_that("setMissingValue works correctly for a single value in XLS", {
     stringsAsFactors = FALSE
   )
   attr(expect, "worksheetScope") <- ""
+  # Check that writing and reading the data with a specific missing value string
+  # returns the original data but with the numeric column as a character and corresonding
+  # missing value (*.xls)
   setMissingValue(wb.xls, value = "missing")
   writeNamedRegion(wb.xls, data, name = name)
+  # Reset missing value string such that missing value string is read as string
   setMissingValue(wb.xls, value = NULL)
   res <- readNamedRegion(wb.xls, name = name)
   expect_equal(res, expect)
 })
 
-test_that("setMissingValue works correctly for a single value in XLSX", {
+test_that("writing and reading data with default missing value behaviour returns original data (XLSX)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookSetMissingValue.xlsx", create = TRUE)
   data <- data.frame(A = c(4.2, -3.2, NA, 1.34), B = c("A", NA, "C", "D"), stringsAsFactors = FALSE)
   name <- "missing"
   createSheet(wb.xlsx, name = name)
   createName(wb.xlsx, name = name, formula = paste(name, "$A$1", sep = "!"))
 
+  # Check that writing and reading the data with the default missing value behaviour returns
+  # the original data (*.xlsx)
   writeNamedRegion(wb.xlsx, data, name = name)
   res <- readNamedRegion(wb.xlsx, name = name)
   attr(data, "worksheetScope") <- ""
@@ -41,14 +49,18 @@ test_that("setMissingValue works correctly for a single value in XLSX", {
     stringsAsFactors = FALSE
   )
   attr(expect, "worksheetScope") <- ""
+  # Check that writing and reading the data with a specific missing value string
+  # returns the original data but with the numeric column as a character and corresonding
+  # missing value (*.xlsx)
   setMissingValue(wb.xlsx, value = "missing")
   writeNamedRegion(wb.xlsx, data, name = name)
+  # Reset missing value string such that missing value string is read as string
   setMissingValue(wb.xlsx, value = NULL)
   res <- readNamedRegion(wb.xlsx, name = name)
   expect_equal(res, expect)
 })
 
-test_that("setMissingValue works with a vector of values in XLS", {
+test_that("reading data with multiple missing value strings works (XLS)", {
   wb.xls <- loadWorkbook("resources/testWorkbookMissingValue.xls", create = FALSE)
   expect <- data.frame(
     A = c(NA, -3.2, 3.4, NA, 8, NA),
@@ -57,13 +69,46 @@ test_that("setMissingValue works with a vector of values in XLS", {
     D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
     stringsAsFactors = FALSE
   )
+  # Check that reading data with multiple missing value strings works (*.xls)
   setMissingValue(wb.xls, value = c("NA", "missing", "empty"))
   res <- readNamedRegion(wb.xls, name = "Missing1")
   attr(expect, "worksheetScope") <- ""
   expect_equal(expect, res)
 })
 
-test_that("setMissingValue works with a vector of values in XLSX", {
+test_that("writing and reading data with same specific missing value string returns original data (XLS)", {
+  wb.xls <- loadWorkbook("resources/testWorkbookSetMissingValue.xls", create = TRUE)
+  data <- data.frame(A = c(4.2, -3.2, NA, 1.34), B = c("A", NA, "C", "D"), stringsAsFactors = FALSE)
+  name <- "missing"
+  createSheet(wb.xls, name = name)
+  createName(wb.xls, name = name, formula = paste(name, "$A$1", sep = "!"))
+
+  # Check that writing and reading the data with a specific missing value string
+  # returns the original data (*.xls)
+  setMissingValue(wb.xls, value = "missing")
+  writeNamedRegion(wb.xls, data, name = name)
+  res <- readNamedRegion(wb.xls, name = name)
+  attr(data, "worksheetScope") <- ""
+  expect_equal(res, data)
+})
+
+test_that("writing and reading data with same specific missing value string returns original data (XLSX)", {
+  wb.xlsx <- loadWorkbook("resources/testWorkbookSetMissingValue.xlsx", create = TRUE)
+  data <- data.frame(A = c(4.2, -3.2, NA, 1.34), B = c("A", NA, "C", "D"), stringsAsFactors = FALSE)
+  name <- "missing"
+  createSheet(wb.xlsx, name = name)
+  createName(wb.xlsx, name = name, formula = paste(name, "$A$1", sep = "!"))
+
+  # Check that writing and reading the data with a specific missing value string
+  # returns the original data (*.xlsx)
+  setMissingValue(wb.xlsx, value = "missing")
+  writeNamedRegion(wb.xlsx, data, name = name)
+  res <- readNamedRegion(wb.xlsx, name = name)
+  attr(data, "worksheetScope") <- ""
+  expect_equal(res, data)
+})
+
+test_that("reading data with multiple missing value strings works (XLSX)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookMissingValue.xlsx", create = FALSE)
   expect <- data.frame(
     A = c(NA, -3.2, 3.4, NA, 8, NA),
@@ -72,13 +117,14 @@ test_that("setMissingValue works with a vector of values in XLSX", {
     D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
     stringsAsFactors = FALSE
   )
+  # Check that reading data with multiple missing value strings works (*.xlsx)
   setMissingValue(wb.xlsx, value = c("NA", "missing", "empty"))
   res <- readNamedRegion(wb.xlsx, name = "Missing1")
   attr(expect, "worksheetScope") <- ""
   expect_equal(expect, res)
 })
 
-test_that("setMissingValue works with a list of values in XLS", {
+test_that("reading data with multiple missing value strings works with list input (XLS)", {
   wb.xls <- loadWorkbook("resources/testWorkbookMissingValue.xls", create = FALSE)
   expect <- data.frame(
     A = c(NA, -3.2, NA, NA, 8, NA),
@@ -87,13 +133,14 @@ test_that("setMissingValue works with a list of values in XLS", {
     D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
     stringsAsFactors = FALSE
   )
+  # Check that reading data with multiple missing value strings works (*.xls)
   setMissingValue(wb.xls, value = list("NA", "missing", "empty", -9999))
   res <- readNamedRegion(wb.xls, name = "Missing2")
   attr(expect, "worksheetScope") <- ""
   expect_equal(expect, res)
 })
 
-test_that("setMissingValue works with a list of values in XLSX", {
+test_that("reading data with multiple missing value strings works with list input (XLSX)", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookMissingValue.xlsx", create = FALSE)
   expect <- data.frame(
     A = c(NA, -3.2, NA, NA, 8, NA),
@@ -102,6 +149,7 @@ test_that("setMissingValue works with a list of values in XLSX", {
     D = as.POSIXct(c("1981-12-01 00:00:00", "1981-12-02 00:00:00", NA, NA, NA, "1981-12-06 00:00:00")),
     stringsAsFactors = FALSE
   )
+  # Check that reading data with multiple missing value strings works (*.xlsx)
   setMissingValue(wb.xlsx, value = list("NA", "missing", "empty", -9999))
   res <- readNamedRegion(wb.xlsx, name = "Missing2")
   attr(expect, "worksheetScope") <- ""

--- a/tests/testthat/test.workbook.setSheetPos.R
+++ b/tests/testthat/test.workbook.setSheetPos.R
@@ -1,18 +1,32 @@
-test_that("test.workbook.setSheetPos", {
+test_that("setting Excel worksheet positions", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWorkbookSetSheetPos.xls", create = TRUE)
   wb.xlsx <- loadWorkbook("resources/testWorkbookSetSheetPos.xlsx", create = TRUE)
+
   createSheet(wb.xls, c("A", "B", "C", "D"))
   createSheet(wb.xlsx, c("A", "B", "C", "D"))
+
+  # Check positions (*.xls)
   setSheetPos(wb.xls, sheet = c("D", "B"), pos = c(2, 1))
   expect_equal(c("B", "A", "D", "C"), getSheets(wb.xls))
   expect_equal(c(A = 2, B = 1, C = 4, D = 3), getSheetPos(wb.xls, sheet = c("A", "B", "C", "D")))
+
+  # Check positions (*.xlsx)
   setSheetPos(wb.xlsx, sheet = c("D", "B"), pos = c(2, 1))
   expect_equal(c("B", "A", "D", "C"), getSheets(wb.xlsx))
   expect_equal(c(A = 2, B = 1, C = 4, D = 3), getSheetPos(wb.xlsx, sheet = c("A", "B", "C", "D")))
+
+  # Check that trying to set a non-existing index (out of bounds) results in an exception (*.xls)
   expect_error(setSheetPos(wb.xls, sheet = "A", pos = -1))
   expect_error(setSheetPos(wb.xls, sheet = "A", pos = 36298))
+
+  # Check that trying to set a non-existing position (out of bounds) results in an exception (*.xlsx)
   expect_error(setSheetPos(wb.xlsx, sheet = "A", pos = -1))
   expect_error(setSheetPos(wb.xlsx, sheet = "A", pos = 36298))
+
+  # Check that trying to set the position of a non-existing worksheet results in an exception (*.xls)
   expect_error(setSheetPos(wb.xls, sheet = "NotThere", pos = 2))
+
+  # Check that trying to set the position of a non-existing worksheet results in an exception (*.xlsx)
   expect_error(setSheetPos(wb.xlsx, sheet = "NotThere", pos = 2))
 })

--- a/tests/testthat/test.workbook.testBug181.R
+++ b/tests/testthat/test.workbook.testBug181.R
@@ -1,4 +1,7 @@
 test_that("test.workbook.testBug181", {
+  # loading this workbook reproduces this error, but only the first time it is loaded during a session
+  # it seems however that this does not prevent the workbook from being read and even when the "error"
+  # is logged it isn't considered an exception and behaves more like a regular log message
   wb <- loadWorkbook("resources/testBug181.xlsx")
   obj <- readWorksheet(wb, "Sheet1")
   expect_true(is.data.frame(obj))

--- a/tests/testthat/test.workbook.testBug181.R
+++ b/tests/testthat/test.workbook.testBug181.R
@@ -1,4 +1,4 @@
-test_that("test.workbook.testBug181", {
+test_that("Test reproducing error log from issue 181 / PR 183", {
   # loading this workbook reproduces this error, but only the first time it is loaded during a session
   # it seems however that this does not prevent the workbook from being read and even when the "error"
   # is logged it isn't considered an exception and behaves more like a regular log message

--- a/tests/testthat/test.workbook.unhideSheet.R
+++ b/tests/testthat/test.workbook.unhideSheet.R
@@ -1,4 +1,4 @@
-test_that("unhideSheet works correctly for xls", {
+test_that("unhiding sheets works correctly for xls format (assumes 'isSheetHidden' and 'isSheetVeryHidden' work correctly)", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xls"), create = FALSE)
   unhideSheet(wb.xls, 2)
   unhideSheet(wb.xls, "DDD")
@@ -6,7 +6,7 @@ test_that("unhideSheet works correctly for xls", {
   expect_false(isSheetVeryHidden(wb.xls, "DDD"))
 })
 
-test_that("unhideSheet works correctly for xlsx", {
+test_that("unhiding sheets works correctly for xlsx format (assumes 'isSheetHidden' and 'isSheetVeryHidden' work correctly)", {
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xlsx"), create = FALSE)
   unhideSheet(wb.xlsx, 2)
   unhideSheet(wb.xlsx, "DDD")
@@ -14,13 +14,13 @@ test_that("unhideSheet works correctly for xlsx", {
   expect_false(isSheetVeryHidden(wb.xlsx, "DDD"))
 })
 
-test_that("unhideSheet throws an error for non-existent sheets in xls", {
+test_that("attempting to unhide an illegal sheet throws an exception for xls format", {
   wb.xls <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xls"), create = FALSE)
   expect_error(unhideSheet(wb.xls, 58), "IllegalArgumentException")
   expect_error(unhideSheet(wb.xls, "SheetWhichDoesNotExist"), "IllegalArgumentException")
 })
 
-test_that("unhideSheet throws an error for non-existent sheets in xlsx", {
+test_that("attempting to unhide an illegal sheet throws an exception for xlsx format", {
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookHiddenSheets.xlsx"), create = FALSE)
   expect_error(unhideSheet(wb.xlsx, 58), "IllegalArgumentException")
   expect_error(unhideSheet(wb.xlsx, "SheetWhichDoesNotExist"), "IllegalArgumentException")

--- a/tests/testthat/test.workbook.writeNamedRegion.R
+++ b/tests/testthat/test.workbook.writeNamedRegion.R
@@ -1,38 +1,49 @@
 test_that("writeNamedRegion throws error for non-data.frame objects in XLS", {
+  # Check that trying to write an object which cannot be converted to a data.frame
+  # causes an exception (*.xls)
   wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
   createName(wb.xls, "test1", "Test1!$C$8")
   expect_error(writeNamedRegion(wb.xls, search, "test1"), "cannot coerce class")
 })
 
 test_that("writeNamedRegion throws error for non-data.frame objects in XLSX", {
+  # Check that trying to write an object which cannot be converted to a data.frame
+  # causes an exception (*.xlsx)
   wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
   createName(wb.xlsx, "test1", "Test1!$C$8")
   expect_error(writeNamedRegion(wb.xlsx, search, "test1"), "cannot coerce class")
 })
 
 test_that("writeNamedRegion throws error for non-existent names in XLS", {
+  # Check that attempting to write to a non-existing name causes an exception (*.xls)
   wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
   expect_error(writeNamedRegion(wb.xls, mtcars, "nameDoesNotExist"), "IllegalArgumentException")
 })
 
 test_that("writeNamedRegion throws error for non-existent names in XLSX", {
+  # Check that attempting to write to a non-existing name causes an exception (*.xlsx)
   wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
   expect_error(writeNamedRegion(wb.xlsx, mtcars, "nameDoesNotExist"), "IllegalArgumentException")
 })
 
 test_that("writeNamedRegion throws error for non-existent sheets in XLS", {
+  # Check that attempting to write to a name which referes to a non-existing sheet
+  # causes an exception (*.xls)
   wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
   createName(wb.xls, "nope", "NonExistingSheet!A1")
   expect_error(writeNamedRegion(wb.xls, mtcars, "nope"), "IllegalArgumentException")
 })
 
 test_that("writeNamedRegion throws error for non-existent sheets in XLSX", {
+  # Check that attempting to write to a name which referes to a non-existing sheet
+  # causes an exception (*.xlsx)
   wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
   createName(wb.xlsx, "nope", "NonExistingSheet!A1")
   expect_error(writeNamedRegion(wb.xlsx, mtcars, "nope"), "IllegalArgumentException")
 })
 
 test_that("writeNamedRegion handles empty data frames in XLS", {
+  # Check that writing an empty data.frame does not cause an error (*.xls)
   wb.xls <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xls", create = TRUE)
   createSheet(wb.xls, "empty")
   createName(wb.xls, "empty1", "empty!A1")
@@ -43,6 +54,7 @@ test_that("writeNamedRegion handles empty data frames in XLS", {
 })
 
 test_that("writeNamedRegion handles empty data frames in XLSX", {
+  # Check that writing an empty data.frame does not cause an error (*.xlsx)
   wb.xlsx <- loadWorkbook("resources/testWorkbookWriteNamedRegion.xlsx", create = TRUE)
   createSheet(wb.xlsx, "empty")
   createName(wb.xlsx, "empty1", "empty!A1")
@@ -52,34 +64,39 @@ test_that("writeNamedRegion handles empty data frames in XLSX", {
   expect_true(TRUE)
 })
 
+# Helper function for testing formula overwrite behavior
+test_overwrite_formula <- function(wb, expected, overwrite = TRUE) {
+  writeNamedRegion(wb, mtcars, "mtcars_formula", overwriteFormulaCells = overwrite)
+  res <- readNamedRegion(wb, "mtcars_formula")
+  expect_equal(res, normalizeDataframe(expected), ignore_attr = TRUE)
+}
+
 test_that("writeNamedRegion with overwriteFormulaCells = FALSE works in XLS", {
+  # Load workbooks with formulas on them
   wb.xls <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xls")
+  # Initialize mtcars_mod as is defined with the formula in the carb column (set equal to the gear column)
   mtcars_mod <- mtcars
   mtcars_mod$carb <- mtcars_mod$gear
-  writeNamedRegion(wb.xls, mtcars, "mtcars_formula", overwriteFormulaCells = FALSE)
-  res <- readNamedRegion(wb.xls, "mtcars_formula")
-  expect_equal(res, normalizeDataframe(mtcars_mod), ignore_attr = TRUE)
+  # Check that formulas can be kept in existing named region (*.xls)
+  test_overwrite_formula(wb.xls, mtcars_mod, overwrite = FALSE)
 })
 
 test_that("writeNamedRegion with overwriteFormulaCells = FALSE works in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xlsx")
   mtcars_mod <- mtcars
   mtcars_mod$carb <- mtcars_mod$gear
-  writeNamedRegion(wb.xlsx, mtcars, "mtcars_formula", overwriteFormulaCells = FALSE)
-  res <- readNamedRegion(wb.xlsx, "mtcars_formula")
-  expect_equal(res, normalizeDataframe(mtcars_mod), ignore_attr = TRUE)
+  # Check that formulas can be kept in existing named region (*.xlsx)
+  test_overwrite_formula(wb.xlsx, mtcars_mod, overwrite = FALSE)
 })
 
 test_that("writeNamedRegion with overwriteFormulaCells = TRUE works in XLS", {
   wb.xls <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xls")
-  writeNamedRegion(wb.xls, mtcars, "mtcars_formula", overwriteFormulaCells = TRUE)
-  res <- readNamedRegion(wb.xls, "mtcars_formula")
-  expect_equal(res, normalizeDataframe(mtcars), ignore_attr = TRUE)
+  # Check that formulas are overwritten (*.xls)
+  test_overwrite_formula(wb.xls, mtcars)
 })
 
 test_that("writeNamedRegion with overwriteFormulaCells = TRUE works in XLSX", {
   wb.xlsx <- loadWorkbook("resources/testWorkbookOverwriteFormulas.xlsx")
-  writeNamedRegion(wb.xlsx, mtcars, "mtcars_formula", overwriteFormulaCells = TRUE)
-  res <- readNamedRegion(wb.xlsx, "mtcars_formula")
-  expect_equal(res, normalizeDataframe(mtcars), ignore_attr = TRUE)
+  # Check that formulas are overwritten (*.xlsx)
+  test_overwrite_formula(wb.xlsx, mtcars)
 })

--- a/tests/testthat/test.workbook.writeWorksheet.R
+++ b/tests/testthat/test.workbook.writeWorksheet.R
@@ -1,43 +1,67 @@
 test_that("writeWorksheet throws error for non-data.frame objects", {
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
-  createSheet(wb, "test1")
-  expect_error(writeWorksheet(wb, search, "test1"))
+  # Create workbooks
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+
+  # Check that trying to write an object which cannot be converted to a data.frame
+  # causes an exception (*.xls)
+  createSheet(wb.xls, "test1")
+  expect_error(writeWorksheet(wb.xls, search, "test1"))
+
+  # Check that trying to write an object which cannot be converted to a data.frame
+  # causes an exception (*.xlsx)
+  createSheet(wb.xlsx, "test1")
+  expect_error(writeWorksheet(wb.xlsx, search, "test1"))
 })
 
 test_that("writeWorksheet throws error for non-existent sheets", {
-  wb <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
-  expect_error(writeWorksheet(wb, mtcars, "sheetDoesNotExist"))
+  # Create workbooks
+  wb.xls <- loadWorkbook(withr::local_tempfile(fileext = ".xls"), create = TRUE)
+  wb.xlsx <- loadWorkbook(withr::local_tempfile(fileext = ".xlsx"), create = TRUE)
+
+  # Check that attempting to write to a non-existing sheet causes an exception (*.xls)
+  expect_error(writeWorksheet(wb.xls, mtcars, "sheetDoesNotExist"))
+
+  # Check that attempting to write to a non-existing sheet causes an exception (*.xlsx)
+  expect_error(writeWorksheet(wb.xlsx, mtcars, "sheetDoesNotExist"))
 })
 
 test_that("writeWorksheet can preserve formulas", {
+  # Load workbooks with formulas on them
   wb.xls <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xls"))
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xlsx"))
 
+  # Initialize mtcars_mod as is defined with the formula in the carb column (set equal to the gear column)
   mtcars_mod <- mtcars
   mtcars_mod$carb <- mtcars_mod$gear
 
-  # Test for .xls
-  writeWorksheet(wb.xls, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = FALSE)
-  res.xls <- readWorksheet(wb.xls, "mtcars_formula")
-  expect_equal(res.xls, normalizeDataframe(mtcars_mod), ignore_attr = c("worksheetScope", "row.names"))
+  test_overwrite_formula <- function(wb, expected, overwrite = TRUE) {
+    writeWorksheet(wb, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = overwrite)
+    res <- readWorksheet(wb, "mtcars_formula")
+    expect_equal(res, normalizeDataframe(expected), ignore_attr = c("worksheetScope", "row.names"))
+  }
 
-  # Test for .xlsx
-  writeWorksheet(wb.xlsx, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = FALSE)
-  res.xlsx <- readWorksheet(wb.xlsx, "mtcars_formula")
-  expect_equal(res.xlsx, normalizeDataframe(mtcars_mod), ignore_attr = c("worksheetScope", "row.names"))
+  # Check that formulas can be kept in existing named region (*.xls)
+  test_overwrite_formula(wb.xls, mtcars_mod, overwrite = FALSE)
+
+  # Check that formulas can be kept in existing named region (*.xlsx)
+  test_overwrite_formula(wb.xlsx, mtcars_mod, overwrite = FALSE)
 })
 
 test_that("writeWorksheet can overwrite formulas", {
+  # Load workbooks with formulas on them
   wb.xls <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xls"))
   wb.xlsx <- loadWorkbook(rsrc("testWorkbookOverwriteFormulas.xlsx"))
 
-  # Test for .xls
-  writeWorksheet(wb.xls, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = TRUE)
-  res.xls <- readWorksheet(wb.xls, "mtcars_formula")
-  expect_equal(res.xls, normalizeDataframe(mtcars), ignore_attr = c("worksheetScope", "row.names"))
+  test_overwrite_formula <- function(wb, expected, overwrite = TRUE) {
+    writeWorksheet(wb, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = overwrite)
+    res <- readWorksheet(wb, "mtcars_formula")
+    expect_equal(res, normalizeDataframe(expected), ignore_attr = c("worksheetScope", "row.names"))
+  }
 
-  # Test for .xlsx
-  writeWorksheet(wb.xlsx, mtcars, "mtcars_formula", startRow = 9, startCol = 5, overwriteFormulaCells = TRUE)
-  res.xlsx <- readWorksheet(wb.xlsx, "mtcars_formula")
-  expect_equal(res.xlsx, normalizeDataframe(mtcars), ignore_attr = c("worksheetScope", "row.names"))
+  # Check that formulas are overwritten (*.xls)
+  test_overwrite_formula(wb.xls, mtcars)
+
+  # Check that formulas are overwritten (*.xlsx)
+  test_overwrite_formula(wb.xlsx, mtcars)
 })

--- a/tests/testthat/test.writeAndReadWorksheet.R
+++ b/tests/testthat/test.writeAndReadWorksheet.R
@@ -1,4 +1,5 @@
-test_that("test.workbook.writeAndReadWorksheet - always run", {
+test_that("checking equality of data.frame's being written to and read from Excel worksheets - always run", {
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWriteAndReadWorksheet.xls", create = TRUE)
   wb.xlsx <- loadWorkbook("resources/testWriteAndReadWorksheet.xlsx", create = TRUE)
   testDataFrame <- function(wb, df, startRow, startCol) {
@@ -8,6 +9,8 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
     res <- readWorksheet(wb, worksheet, startRow = startRow, startCol = startCol, endRow = 0, endCol = 0)
     expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope"))
   }
+
+  # custom test dataset
   cdf <- data.frame(
     Column.A = c(1, 2, 3, NA, 5, 6, 7, 8, NA, 10),
     Column.B = c(-4, -3, NA, -1, 0, NA, NA, 3, 4, 5),
@@ -17,6 +20,7 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
     Column.F = c("High", "Medium", "Low", "Low", "Low", NA, NA, "Medium", "High", "High"),
     Column.G = c("High", "Medium", NA, "Low", "Low", "Medium", NA, "Medium", "High", "High"),
     Column.H = rep(c(as.Date("2021-10-30"), as.Date("2021-03-28"), NA), length = 10),
+    # NOTE: Column.I is automatically converted to POSIXct!!!
     Column.I = rep(
       c(
         as.POSIXlt("2021-10-31 03:00:00"),
@@ -26,6 +30,7 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
       ),
       length = 10
     ),
+    # NOTE: 1582963631 with origin="1970-01-01" corresponds to 2020 Feb 29
     Column.J = rep(
       c(
         as.POSIXct("2021-10-31 03:00:00"),
@@ -39,21 +44,32 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
   )
   cdf[["Column.F"]] <- factor(cdf[["Column.F"]])
   cdf[["Column.F"]] <- ordered(cdf[["Column.F"]], levels = c("Low", "Medium", "High"))
+
+  # (*.xls)
   testDataFrame(wb.xls, cdf, 1, 1)
+  # (*.xlsx)
   testDataFrame(wb.xlsx, cdf, 1, 1)
+
+  # Check writing of data.frame with row names (*.xls)
   createSheet(wb.xls, "rownames")
   writeWorksheet(wb.xls, mtcars, "rownames", startRow = 9, startCol = 10, header = TRUE, rownames = "Car")
   res <- readWorksheet(wb.xls, "rownames", startRow = 9, startCol = 10)
   expect_equal(res, XLConnect:::includeRownames(mtcars, "Car"))
+
+  # Check writing of data.frame with row names (*.xlsx)
   createSheet(wb.xlsx, "rownames")
   writeWorksheet(wb.xlsx, mtcars, "rownames", startRow = 9, startCol = 10, header = TRUE, rownames = "Car")
   res <- readWorksheet(wb.xlsx, "rownames", startRow = 9, startCol = 10)
   expect_equal(res, XLConnect:::includeRownames(mtcars, "Car"))
+
+  # Check writing & reading of data.frame with row names (*.xls)
   createSheet(wb.xls, name = "rownames2")
   writeWorksheet(wb.xls, mtcars, "rownames2", startRow = 31, startCol = 8, header = TRUE, rownames = "Car")
   res <- readWorksheet(wb.xls, "rownames2", rownames = "Car")
   expect_equal(res, mtcars)
   expect_equal(attr(res, "row.names"), attr(mtcars, "row.names"))
+
+  # Check writing & reading of data.frame with row names (*.xlsx)
   createSheet(wb.xlsx, name = "rownames2")
   writeWorksheet(wb.xlsx, mtcars, "rownames2", startRow = 31, startCol = 8, header = TRUE, rownames = "Car")
   res <- readWorksheet(wb.xlsx, "rownames2", rownames = "Car")
@@ -61,9 +77,10 @@ test_that("test.workbook.writeAndReadWorksheet - always run", {
   expect_equal(attr(res, "row.names"), attr(mtcars, "row.names"))
 })
 
-test_that("test.workbook.writeAndReadWorksheet - full test suite only", {
+test_that("checking equality of data.frame's being written to and read from Excel worksheets - full test suite only", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
 
+  # Create workbooks
   wb.xls <- loadWorkbook("resources/testWriteAndReadWorksheet.xls", create = TRUE)
   wb.xlsx <- loadWorkbook("resources/testWriteAndReadWorksheet.xlsx", create = TRUE)
   testDataFrame <- function(wb, df, startRow, startCol) {
@@ -73,22 +90,49 @@ test_that("test.workbook.writeAndReadWorksheet - full test suite only", {
     res <- readWorksheet(wb, worksheet, startRow = startRow, startCol = startCol, endRow = 0, endCol = 0)
     expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope", "row.names"))
   }
+
+  # built-in dataset mtcars (*.xls)
   testDataFrame(wb.xls, mtcars, 8, 13)
+  # built-in dataset mtcars (*.xlsx)
   testDataFrame(wb.xlsx, mtcars, 8, 13)
+
+  # built-in dataset airquality (*.xls)
   testDataFrame(wb.xls, airquality, 2, 9)
+  # built-in dataset airquality (*.xlsx)
   testDataFrame(wb.xlsx, airquality, 2, 9)
+
+  # built-in dataset attenu (*.xls)
   testDataFrame(wb.xls, attenu, 7, 1)
+  # built-in dataset attenu (*.xlsx)
   testDataFrame(wb.xlsx, attenu, 7, 1)
+
+  # built-in dataset ChickWeight (*.xls)
   testDataFrame(wb.xls, ChickWeight, 8, 8)
+  # built-in dataset ChickWeight (*.xlsx)
   testDataFrame(wb.xlsx, ChickWeight, 8, 8)
+
+  # built-in dataset CO2 (*.xls)
   testDataFrame(wb.xls, CO2, 100, 12)
+  # built-in dataset CO2 (*.xlsx)
   testDataFrame(wb.xlsx, CO2, 100, 12)
+
+  # built-in dataset iris (*.xls)
   testDataFrame(wb.xls, iris, 1, 1)
+  # built-in dataset iris (*.xlsx)
   testDataFrame(wb.xlsx, iris, 1, 1)
+
+  # built-in dataset longley (*.xls)
   testDataFrame(wb.xls, longley, 5, 214)
+  # built-in dataset longley (*.xlsx)
   testDataFrame(wb.xlsx, longley, 5, 214)
+
+  # built-in dataset morley (*.xls)
   testDataFrame(wb.xls, morley, 1000, 6)
+  # built-in dataset morley (*.xlsx)
   testDataFrame(wb.xlsx, morley, 1000, 6)
+
+  # built-in dataset swiss (*.xls)
   testDataFrame(wb.xls, swiss, 4, 4)
+  # built-in dataset swiss (*.xlsx)
   testDataFrame(wb.xlsx, swiss, 4, 4)
 })

--- a/tests/testthat/test.writeNamedRegionToFile.R
+++ b/tests/testthat/test.writeNamedRegionToFile.R
@@ -1,11 +1,14 @@
-test_that("test.writeNamedRegionToFile - full test suite only", {
+test_that("writeNamedRegionToFile - checking equality of data.frame's being written to and read from Excel worksheets", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
 
+  # Create workbooks
   file.xls <- "testWriteNamedRegionToFileWorkbook.xls"
   file.xlsx <- "testWriteNamedRegionToFileWorkbook.xlsx"
+
   if (file.exists(file.xls)) {
     file.remove(file.xls)
   }
+
   if (file.exists(file.xlsx)) {
     file.remove(file.xlsx)
   }
@@ -17,35 +20,64 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
     res <- readNamedRegionFromFile(file, name)
     expect_equal(normalizeDataframe(df), res, ignore_attr = c("worksheetScope", "row.names"))
   }
+
+  # built-in dataset mtcars (*.xls)
   testDataFrame(file.xls, mtcars)
+  # built-in dataset mtcars (*.xlsx)
   testDataFrame(file.xlsx, mtcars)
+
+  # built-in dataset airquality (*.xls)
   testDataFrame(file.xls, airquality)
+  # built-in dataset airquality (*.xlsx)
   testDataFrame(file.xlsx, airquality)
+
+  # built-in dataset attenu (*.xls)
   testDataFrame(file.xls, attenu)
+  # built-in dataset attenu (*.xlsx)
   testDataFrame(file.xlsx, attenu)
+
+  # built-in dataset ChickWeight (*.xls)
   testDataFrame(file.xls, ChickWeight)
+  # built-in dataset ChickWeight (*.xlsx)
   testDataFrame(file.xlsx, ChickWeight)
-  CO = CO2
+
+  CO = CO2 # CO2 seems to be an illegal name
+  # built-in dataset CO2 (*.xls)
   testDataFrame(file.xls, CO)
+  # built-in dataset CO2 (*.xlsx)
   testDataFrame(file.xlsx, CO)
+
+  # built-in dataset iris (*.xls)
   testDataFrame(file.xls, iris)
+  # built-in dataset iris (*.xlsx)
   testDataFrame(file.xlsx, iris)
+
+  # built-in dataset longley (*.xls)
   testDataFrame(file.xls, longley)
+  # built-in dataset longley (*.xlsx)
   testDataFrame(file.xlsx, longley)
+
+  # built-in dataset morley (*.xls)
   testDataFrame(file.xls, morley)
+  # built-in dataset morley (*.xlsx)
   testDataFrame(file.xlsx, morley)
+
+  # built-in dataset swiss (*.xls)
   testDataFrame(file.xls, swiss)
+  # built-in dataset swiss (*.xlsx)
   testDataFrame(file.xlsx, swiss)
+  # custom test dataset
   cdf <- data.frame(
-    Column.A = c(1, 2, 3, NA, 5, 6, 7, 8, NA, 10),
-    Column.B = c(-4, -3, NA, -1, 0, NA, NA, 3, 4, 5),
-    Column.C = c("Anna", "???", NA, "", NA, "$!?&%", "(?2@?~?'^*#|)", "{}[]:,;-_<>", "\\sadf\n\nv", "a b c"),
-    Column.D = c(pi, -pi, NA, sqrt(2), sqrt(0.3), -sqrt(pi), exp(1), log(2), sin(2), -tan(2)),
-    Column.E = c(TRUE, TRUE, NA, NA, FALSE, FALSE, TRUE, NA, FALSE, TRUE),
-    Column.F = c("High", "Medium", "Low", "Low", "Low", NA, NA, "Medium", "High", "High"),
-    Column.G = c("High", "Medium", NA, "Low", "Low", "Medium", NA, "Medium", "High", "High"),
-    Column.H = rep(c(as.Date("2021-10-30"), as.Date("2021-03-28"), NA), length = 10),
-    Column.I = rep(
+    "Column.A" = c(1, 2, 3, NA, 5, 6, 7, 8, NA, 10),
+    "Column.B" = c(-4, -3, NA, -1, 0, NA, NA, 3, 4, 5),
+    "Column.C" = c("Anna", "???", NA, "", NA, "$!?&%", "(?2@?~?'^*#|)", "{}[]:,;-_<>", "\\sadf\n\nv", "a b c"),
+    "Column.D" = c(pi, -pi, NA, sqrt(2), sqrt(0.3), -sqrt(pi), exp(1), log(2), sin(2), -tan(2)),
+    "Column.E" = c(TRUE, TRUE, NA, NA, FALSE, FALSE, TRUE, NA, FALSE, TRUE),
+    "Column.F" = c("High", "Medium", "Low", "Low", "Low", NA, NA, "Medium", "High", "High"),
+    "Column.G" = c("High", "Medium", NA, "Low", "Low", "Medium", NA, "Medium", "High", "High"),
+    "Column.H" = rep(c(as.Date("2021-10-30"), as.Date("2021-03-28"), NA), length = 10),
+    # NOTE: Column.I is automatically converted to POSIXct!!!
+    "Column.I" = rep(
       c(
         as.POSIXlt("2021-10-31 03:00:00"),
         as.POSIXlt(1582963631, origin = "1970-01-01"),
@@ -54,7 +86,8 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
       ),
       length = 10
     ),
-    Column.J = rep(
+    # NOTE: 1582963631 with origin="1970-01-01" corresponds to 2020 Feb 29
+    "Column.J" = rep(
       c(
         as.POSIXct("2021-10-31 03:00:00"),
         as.POSIXct(1582963631, origin = "1970-01-01"),
@@ -67,7 +100,10 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
   )
   cdf[["Column.F"]] <- factor(cdf[["Column.F"]])
   cdf[["Column.F"]] <- ordered(cdf[["Column.F"]], levels = c("Low", "Medium", "High"))
+
+  # (*.xls)
   testDataFrame(file.xls, cdf)
+  # (*.xlsx)
   testDataFrame(file.xlsx, cdf)
   file2.xls <- "wnrtf1.xls"
   file2.xlsx <- "wnrtf1.xlsx"
@@ -77,23 +113,37 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
   if (file.exists(file2.xlsx)) {
     file.remove(file2.xlsx)
   }
+  # Check that writing a data.frame to a named region with a formula that contains a white space in
+  # the sheet name does not cause any grief (*.xls)
   expect_error(
     writeNamedRegionToFile(file2.xls, data = mtcars, name = "mtcars", formula = "'My Cars'!$A$1", header = TRUE),
     NA
   )
   expect_true(file.exists(file2.xls))
+
+  # Check that writing a data.frame to a named region with a formula that contains a white space in
+  # the sheet name does not cause any grief (*.xlsx)
   expect_error(
     writeNamedRegionToFile(file2.xlsx, data = mtcars, name = "mtcars", formula = "'My Cars'!$A$1", header = TRUE),
     NA
   )
   expect_true(file.exists(file2.xlsx))
+
+  # test clearNamedRegions
   testClearNamedRegions <- function(file, df) {
     df.short <- df[1, ]
+
+    # overwrite named region with shorter version
     writeNamedRegionToFile(file, data = df.short, name = "cdfRegion")
+    # default behaviour: not cleared, only named region is shortened
     expect_equal(nrow(readNamedRegionFromFile(file, name = "cdfRegion")), 1)
     expect_equal(nrow(readWorksheetFromFile(file, sheet = "cdf")), nrow(df))
+
+    # rewrite longer version
     writeNamedRegionToFile(file, data = df, name = "cdfRegion")
+    # overwrite name with shorter version & clearing
     writeNamedRegionToFile(file, data = df.short, name = "cdfRegion", clearNamedRegions = TRUE)
+    # should be cleared
     expect_equal(nrow(readNamedRegionFromFile(file, name = "cdfRegion")), 1)
     expect_equal(nrow(readWorksheetFromFile(file, sheet = "cdf")), 1)
   }
@@ -112,13 +162,18 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
       name = "cdfRegionScoped",
       formula = paste(scope, "A1", sep = "!"),
       worksheetScope = scope
-    )
+    ) # should write in cell A1 in each sheet
+    # overwrite named region with shorter version
     writeNamedRegionToFile(file, data = df.short, name = "cdfRegionScoped", worksheetScope = scope)
+    # default behaviour: not cleared, only named region is shortened
     expect_equal(nrow(readNamedRegionFromFile(file, name = "cdfRegionScoped", worksheetScope = scope)[[1]]), 1)
     expect_equal(nrow(readNamedRegionFromFile(file, name = "cdfRegionScoped", worksheetScope = scope)[[2]]), 1)
     expect_equal(nrow(readWorksheetFromFile(file, sheet = scope)[[1]]), nrow(df))
     expect_equal(nrow(readWorksheetFromFile(file, sheet = scope)[[2]]), nrow(df))
+
+    # rewrite longer version
     writeNamedRegionToFile(file, data = df, name = "cdfRegionScoped", worksheetScope = scope)
+    # overwrite name with shorter version & clearing
     writeNamedRegionToFile(
       file,
       data = df.short,
@@ -126,6 +181,7 @@ test_that("test.writeNamedRegionToFile - full test suite only", {
       clearNamedRegions = clearParam,
       worksheetScope = scope
     )
+    # should be cleared
     expect_equal(nrow(readNamedRegionFromFile(file, name = "cdfRegionScoped", worksheetScope = scope)[[1]]), 1)
     expect_equal(nrow(readNamedRegionFromFile(file, name = "cdfRegionScoped", worksheetScope = scope)[[2]]), 1)
     expect_equal(nrow(readWorksheetFromFile(file, sheet = scope)[[1]]), 1)

--- a/tests/testthat/test.writeWorksheetToFile.R
+++ b/tests/testthat/test.writeWorksheetToFile.R
@@ -16,7 +16,7 @@ testDataFrame <- function(file, df) {
 }
 
 
-test_that("test.writeWorksheetToFile - full test suite only", {
+test_that("checking equality of data.frames being written to and read from Excel worksheets - full test suite only", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
   file.xls <- withr::local_tempfile(fileext = ".xls")
   file.xlsx <- withr::local_tempfile(fileext = ".xlsx")
@@ -29,7 +29,7 @@ test_that("test.writeWorksheetToFile - full test suite only", {
   testDataFrame(file.xlsx, attenu)
   testDataFrame(file.xls, ChickWeight)
   testDataFrame(file.xlsx, ChickWeight)
-  CO = CO2
+  CO = CO2 # CO2 seems to be an illegal name
   testDataFrame(file.xls, CO2)
   testDataFrame(file.xlsx, CO2)
   testDataFrame(file.xls, iris)
@@ -49,6 +49,7 @@ test_that("test.writeWorksheetToFile - full test suite only", {
     Column.F = c("High", "Medium", "Low", "Low", "Low", NA, NA, "Medium", "High", "High"),
     Column.G = c("High", "Medium", NA, "Low", "Low", "Medium", NA, "Medium", "High", "High"),
     Column.H = rep(c(as.Date("2021-10-30"), as.Date("2021-03-28"), NA), length = 10),
+    # NOTE: Column.I is automatically converted to POSIXct!!!
     Column.I = rep(
       c(
         as.POSIXlt("2021-10-31 03:00:00"),
@@ -58,6 +59,7 @@ test_that("test.writeWorksheetToFile - full test suite only", {
       ),
       length = 10
     ),
+    # NOTE: 1582963631 with origin="1970-01-01" corresponds to 2020 Feb 29
     Column.J = rep(
       c(
         as.POSIXct("2021-10-31 03:00:00"),
@@ -76,7 +78,7 @@ test_that("test.writeWorksheetToFile - full test suite only", {
 })
 
 
-test_that("clearSheets parameter works correctly for XLS", {
+test_that("clearSheets parameter works correctly for XLS - test clearSheets", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
   file.xls <- withr::local_tempfile(fileext = ".xls")
 
@@ -85,15 +87,19 @@ test_that("clearSheets parameter works correctly for XLS", {
 
   writeWorksheetToFile(file.xls, data = df.short, sheet = "cdfRegion")
 
+  # overwrite sheet with longer version
   writeWorksheetToFile(file.xls, data = cdf, sheet = "cdfRegion")
+  # default behaviour: not cleared
   expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(cdf))
 
+  # overwrite sheet with shorter version
   writeWorksheetToFile(file.xls, data = df.short, sheet = "cdfRegion", clearSheets = TRUE)
+  # should be cleared
   expect_equal(nrow(readWorksheetFromFile(file.xls, sheet = "cdfRegion")), nrow(df.short))
 })
 
 
-test_that("clearSheets parameter works correctly for XLSX", {
+test_that("clearSheets parameter works correctly for XLSX - test clearSheets", {
   skip_if_not(getOption("FULL.TEST.SUITE"), "FULL.TEST.SUITE is not TRUE")
   file.xlsx <- withr::local_tempfile(fileext = ".xlsx")
 
@@ -102,9 +108,13 @@ test_that("clearSheets parameter works correctly for XLSX", {
 
   writeWorksheetToFile(file.xlsx, data = df.short, sheet = "cdfRegion")
 
+  # overwrite sheet with longer version
   writeWorksheetToFile(file.xlsx, data = cdf, sheet = "cdfRegion")
+  # default behaviour: not cleared
   expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(cdf))
 
+  # overwrite sheet with shorter version
   writeWorksheetToFile(file.xlsx, data = df.short, sheet = "cdfRegion", clearSheets = TRUE)
+  # should be cleared
   expect_equal(nrow(readWorksheetFromFile(file.xlsx, sheet = "cdfRegion")), nrow(df.short))
 })


### PR DESCRIPTION
Transferred explanatory comments from the legacy `runit` test files in `inst/unitTests` to their `testthat` equivalents in `tests/testthat`.

This ensures that important context and explanations from the original tests are not lost in the new test suite.

The following files were modified:
- tests/testthat/test.dataframeConversion.R
- tests/testthat/test.loadWorkbook.R
- tests/testthat/test.workbook.createName.R
- tests/testthat/test.configurePOI.R
- tests/testthat/test.dumpAndRestore.R
- tests/testthat/test.workbook.testBug181.R
- tests/testthat/test.workbook.extraction.R